### PR TITLE
Add Prism styling to the <code> markdown blocks

### DIFF
--- a/content/blog/2018-02-01-using-hpe-onesphere-javascript-package.md
+++ b/content/blog/2018-02-01-using-hpe-onesphere-javascript-package.md
@@ -17,6 +17,7 @@ When a developer [installs Node](https://nodejs.org/en/), it comes bundled with 
 
 # Starting the Project
 Let's start by creating a new project directory I called mine `hpe-onesphere-js-app`. In your terminal window within this directory initiate your project by running `npm init -y`, the `-y` lets NPM know we want to accept whatever default project name value it chooses. After running the `init` command you will see an output similar to the following:
+
 ```json
 {
   "name": "hpe-onesphere-js-app",
@@ -37,6 +38,7 @@ These are the contents of your `package.json` file.
 Our next step is to get our Node/Express API ready. In your project's directory, run the following command `npm i -S express babel-cli babel-preset-env`. This will install the express, babel-cli, and babel-preset packages, the `-S` lets NPM know these packages are project dependencies not just development dependencies. We will be using express as our web server. Babel-cli is used to allow us to include the latest Javascript syntax to our code. To learn more about why developers choose babel check out [this article](https://kleopetrov.me/2016/03/18/everything-about-babel/).
 
 Our next step is to create a `.babelrc` in our base project directory, this file tells babel what extra features of the latest Javascript spec to include. We will be including the latest spec which will allow us to use imports, consts, and arrow functions in our project. To learn more about the latest Javascript syntax features, check out this [handy repo](https://github.com/lukehoban/es6features). The contents of our `.babelrc` should look like this:
+
 ```json
 {
   "presets": ["env"],
@@ -45,6 +47,7 @@ Our next step is to create a `.babelrc` in our base project directory, this file
 ```
 
 Now, create an `index.js` file in your project folder. This will be the entry point for our project. Your index.js should look like the following:
+
 ```javascript
 // Import the express npm package from our node_modules directory.
 import express from 'express';
@@ -62,6 +65,7 @@ app.listen(3000, () => {
   // Send a message to our terminal window that we're ready for action.
   console.log('Server listening to http://localhost:3000');
 });
+
 ``` 
 I've added comments in the code to clarify what each line of code is doing to help create our application. Save your `index.js` file and open your terminal. In the project directory, run `npx babel-node index.js`, this runs our current application in Node. We're running our application in babel-node to transpile the latest Javascript features to lower versions of Javascript on the fly. *Note: babel-node is being used here for demonstration purposes and ease of use, babel-node should not be used in production. Instead a developer would look to transpiling their Javascript to a distribution bundle via [Webpack](https://webpack.js.org/).*
 
@@ -69,6 +73,7 @@ Upon running the babel-node command you should see `Server listening to http://l
 
 # NPM Scripts
 Now that we've learned how to run our project, let's look at a quicker method of handling spinning up our application. In your `package.json` file, in the `"scripts"` key, let's add the script  `"start": npx babel-node index.js`. Your `package.json` should look like this:
+
 ```json
 {
   "name": "hpe-onesphere-js-app",
@@ -93,10 +98,12 @@ Now we can run our project by simply typing `npm start` in our terminal.
 
 # Time to OneSphere
 We'll start by adding the HPE OneSphere Javascript language bindings to our app by running `npm i -S npm i @hpe/hpe-onesphere-js` in our terminal. Once the package has been installed open your `index.js`. Next, we will add the OneSphere package with the following import statement:
+
 ```
 import OneSphere from '@hpe/hpe-onesphere-js';`
 ```
 Then instantiate the class with our host name.
+
 ```javascript
 const oneSphere = new OneSphere('https://my-instance-name.hpeonesphere.com');
 ```
@@ -105,6 +112,7 @@ Now that we have our `oneSphere` class instance we can start to communicate with
 
 # Sessions
 Most requests to OneSphere's API require the user to post  session details. We accomplish this by calling the `postSession` method, this will initiate a session in our class that will be re-used every time we make a request. Just below your `oneSphere` instantiation, add a request to post a session.
+
 ```javascript
 oneSphere.postSession({
   username: 'user@email.com',
@@ -115,6 +123,7 @@ If you run `npm start` in your terminal now you should see a message logged to y
 
 # A Real Live API Route
 The finish line is in sight, an OneSphere API route for our app. Let's create a route to check the OneSphere server status. Below your hello world route add the following:
+
 ```javascript
 app.get('/onesphere-status', (req, res) => {
   oneSphere.getStatus()
@@ -122,6 +131,7 @@ app.get('/onesphere-status', (req, res) => {
 });
 ```
 If we `npm start` our app and check the `http://localhost:3000/onesphere-status` URL in our browser, we should see the following JSON output:
+
 ```json
 {
   "service": "OK",
@@ -132,6 +142,7 @@ Well there it is, the service is running and we have successfully created an HPE
 
 # Error Handling
 This is great and all but what about when we get an error during our API request? Javascript has a great way of handling promise chain failures known as a `catch` statement. Let's add a `catch` to our server status route.
+
 ```javascript
 app.get('/onesphere-status', (req, res) => {
   oneSphere.getStatus()
@@ -142,6 +153,7 @@ app.get('/onesphere-status', (req, res) => {
 With `catch` in place if an error happens in the `then` block `catch` will takeover and handle things from there. Notice we introduced sending the HTTP response code with `status`. This is very helpful when communicating with an API from a front end application, as the developer can decide what to do based on the response code not just the content of the response body.
 
 Here's our final application:
+
 ```javascript
 // Import the express and HPE OneSphere package from our node_modules directory.
 import express from 'express';

--- a/content/blog/2019-08-21-how-to-register-a-grommet-osb-broker-in-a-kubernetes-service-catalog.md
+++ b/content/blog/2019-08-21-how-to-register-a-grommet-osb-broker-in-a-kubernetes-service-catalog.md
@@ -135,6 +135,7 @@ Notice that the status reflects that the broker's catalog of service offerings h
 ## Step 3 – Viewing ClusterServiceClasses and ClusterServicePlans
 
 The controller has already created a ClusterServiceClass for each service that the grommet broker provides. We can view the ClusterServiceClass resources available:
+
 ```bash
 $ svcat get classes
    NAME     NAMESPACE     DESCRIPTION
@@ -147,6 +148,7 @@ NAME                                   EXTERNAL-NAME   BROKER           AGE
 
 ```
 * NOTE: The above kubectl command uses a custom set of columns. The NAME field is the Kubernetes name of the ClusterServiceClass and the EXTERNAL NAME field is the human-readable name for the service that the broker returns.
+
 ```bash
 $ svcat describe class grommet
   Name:              grommet
@@ -204,6 +206,7 @@ status:
   removedFromBrokerCatalog: false
 ```
 Additionally, the controller created a ClusterServicePlan for each of the plans for the broker's services. We can view the ClusterServicePlan resources available in the cluster:
+
 ```bash
 $ svcat get plans
        NAME        NAMESPACE    CLASS     DESCRIPTION
@@ -218,6 +221,7 @@ e3c4f66b-b7ae-4f64-b5a3-51c910b19ac0   grommet-plan-2   grommet-broker   97ca7e2
 
 ```
 You can view the details of a ClusterServicePlan with this command:
+
 ```bash
 $ svcat describe plan grommet/default
 
@@ -261,6 +265,7 @@ $ kubectl create namespace grommet-ns
 namespace/grommet-ns created
 ```
 Then, create the ServiceInstance:
+
 ```bash
 $ cat grommet-broker-instance.yaml
 apiVersion: servicecatalog.k8s.io/v1beta1
@@ -465,11 +470,13 @@ grommet-broker-binding   Opaque                                2      3m37s
 
 ## Step 6 – Delete the ServiceBinding
 Now, let's unbind the instance:
+
 ```bash
 $ svcat unbind -n grommet-ns grommet-broker-instance
 deleted grommet-broker-binding
 ```
 After the deletion is complete, we should see that the Secret is gone:
+
 ```bash
 $ kubectl get secrets -n grommet-ns
 NAME                  TYPE                                  DATA   AGE
@@ -477,6 +484,7 @@ default-token-hjm6z   kubernetes.io/service-account-token   3      154m
 ```
 ## Step 7 – Deleting the ServiceInstance
 There may be times you want to delete a ServiceInstance. In that case you can deprovision it. You can do so using the following steps:
+
 ```bash
 $ svcat deprovision -n grommet-ns grommet-broker-instance
 deleted grommet-broker-instance
@@ -484,6 +492,7 @@ deleted grommet-broker-instance
 
 ## Step 8 – Deleting the ClusterServiceBroker
 Next, remove the ClusterServiceBroker resource. This tells the service catalog to remove the broker's services from the catalog. Do so with this command:
+
 ```bash
 $ kubectl delete clusterservicebrokers grommet-broker
 clusterservicebroker.servicecatalog.k8s.io "grommet-broker" deleted

--- a/content/blog/2019-09-09-complex-stateful-applications-on-kubernetes-kubedirector-version-02.md
+++ b/content/blog/2019-09-09-complex-stateful-applications-on-kubernetes-kubedirector-version-02.md
@@ -1,5 +1,6 @@
 ---
-title: Complex Stateful Applications on Kubernetes&#58; KubeDirector version 0.2
+title: >
+    Complex Stateful Applications on Kubernetes: KubeDirector version 0.2
 date: 2019-09-09T17:26:49.571Z
 author: Tom Phelan 
 tags: ["bluedata"]

--- a/content/blog/2019-09-09-deploying-complex-stateful-applications-on-kubernetes-with-kubedirector.md
+++ b/content/blog/2019-09-09-deploying-complex-stateful-applications-on-kubernetes-with-kubedirector.md
@@ -5,8 +5,15 @@ author: Tom Phelan & Joel Baxter
 tags: ["bluedata"]
 path: deploying-complex-stateful-applications-on-kubernetes-with-kubedirector
 ---
+
+# Deploying Complex Stateful Applications on Kubernetes with KubeDirector
+
+[Deploying Complex Stateful Applications on Kubernetes with KubeDirector](https://www.youtube.com/watch?v=T5wmz7XaKZs)
+
 Kubernetes is clearly the container orchestrator of choice for cloud-native stateless applications. And with StatefulSets and Persistent Volumes, it’s now possible to run stateful applications on Kubernetes. Tools like Kustomize, Helm, and Kubeflow help tackle some of the deployment complexity for stateful applications. However, running complex stateful applications for distributed AI, machine learning, and big data analytics on Kubernetes remains beyond the reach of most users.
 
 Enter KubeDirector. KubeDirector is an open source Apache project that uses the standard Kubernetes custom resource functionality and API extensions to deploy and manage complex stateful scale-out application clusters. With KubeDirector, you can run complex stateful clusters for AI, machine learning, and big data analytics on Kubernetes without writing a single line of Go code.
 
 This webinar will provide an overview of the KubeDirector architecture, show how to author the metadata and artifacts required for an example stateful application (e.g. with Spark, Jupyter, and Cassandra), and demonstrate the deployment and management of the cluster on Kubernetes using KubeDirector.
+
+[![](Download) Download Slides](https://www.cncf.io/wp-content/uploads/2019/05/CNCF-BlueData-final.pdf)

--- a/content/blog/2019-09-09-kubedirector-the-easy-way-to-run-complex-stateful-applications-on-kubern.md
+++ b/content/blog/2019-09-09-kubedirector-the-easy-way-to-run-complex-stateful-applications-on-kubern.md
@@ -1,5 +1,6 @@
 ---
-title: KubeDirector&#58; The easy way to run complex stateful applications on Kubernetes
+title: >
+    KubeDirector: The easy way to run complex stateful applications on Kubernetes
 date: 2019-09-09T17:42:49.847Z
 author: Tom Phelan 
 tags: ["bluedata"]
@@ -16,9 +17,15 @@ KubeDirector provides the following capabilities:
 * An application-agnostic deployment pattern, minimizing the time to onboard new stateful applications to Kubernetes.
 KubeDirector enables data scientists familiar with data-intensive distributed applications such as Hadoop, Spark, Cassandra, TensorFlow, Caffe2, etc. to run these applications on Kubernetes – with a minimal learning curve and no need to write GO code. The applications controlled by KubeDirector are defined by some basic metadata and an associated package of configuration artifacts. The application metadata is referred to as a KubeDirectorApp resource.
 
-To understand the components of KubeDirector, clone the repository on [GitHub](https://github.com/bluek8s/kubedirector/) using a command similar to:```
+To understand the components of KubeDirector, clone the repository on [GitHub](https://github.com/bluek8s/kubedirector/) using a command similar to:
+
+```
 git clone http://<userid>@github.com/bluek8s/kubedirector.
-```The KubeDirectorApp definition for the Spark 2.2.1 application is located in the file `kubedirector/deploy/example_catalog/cr-app-spark221e2.json`.```
+```
+
+The KubeDirectorApp definition for the Spark 2.2.1 application is located in the file `kubedirector/deploy/example_catalog/cr-app-spark221e2.json`.
+
+```
  ~> cat kubedirector/deploy/example_catalog/cr-app-spark221e2.json
  {
     "apiVersion": "kubedirector.bluedata.io/v1alpha1",
@@ -38,7 +45,11 @@ git clone http://<userid>@github.com/bluek8s/kubedirector.
                         "spark_worker"
                     ],
 …
-```The configuration of an application cluster is referred to as a KubeDirectorCluster resource. The KubeDirectorCluster definition for a sample Spark 2.2.1 cluster is located in the file `kubedirector/deploy/example_clusters/cr-cluster-spark221.e1.yaml`.```
+```
+
+The configuration of an application cluster is referred to as a KubeDirectorCluster resource. The KubeDirectorCluster definition for a sample Spark 2.2.1 cluster is located in the file `kubedirector/deploy/example_clusters/cr-cluster-spark221.e1.yaml`.
+
+```
 ~> cat kubedirector/deploy/example_clusters/cr-cluster-spark221.e1.yaml
 apiVersion: "kubedirector.bluedata.io/v1alpha1"
 kind: "KubeDirectorCluster"
@@ -67,14 +78,20 @@ spec:
         cpu: "2"
   - name: jupyter
 …
-```## Running Spark on Kubernetes with KubeDirector
+```
+
+## Running Spark on Kubernetes with KubeDirector
 With KubeDirector, it’s easy to run Spark clusters on Kubernetes.
 
-First, verify that Kubernetes (version 1.9 or later) is running, using the command `kubectl version````
+First, verify that Kubernetes (version 1.9 or later) is running, using the command `kubectl version`
+
+```
 ~> kubectl version
 Client Version: version.Info{Major:"1", Minor:"11", GitVersion:"v1.11.3", GitCommit:"a4529464e4629c21224b3d52edfe0ea91b072862", GitTreeState:"clean", BuildDate:"2018-09-09T18:02:47Z", GoVersion:"go1.10.3", Compiler:"gc", Platform:"linux/amd64"}
 Server Version: version.Info{Major:"1", Minor:"11", GitVersion:"v1.11.3", GitCommit:"a4529464e4629c21224b3d52edfe0ea91b072862", GitTreeState:"clean", BuildDate:"2018-09-09T17:53:03Z", GoVersion:"go1.10.3", Compiler:"gc", Platform:"linux/amd64"} 
-```Deploy the KubeDirector service and the example KubeDirectorApp resource definitions with the commands:
+```
+
+Deploy the KubeDirector service and the example KubeDirectorApp resource definitions with the commands:
 
 ```
 cd kubedirector

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -66,7 +66,7 @@ module.exports = {
               wrapperStyle: 'margin-bottom: 1.0725rem',
             },
           },
-          'gatsby-remark-prismjs',
+          // 'gatsby-remark-prismjs',
           'gatsby-remark-copy-linked-files',
           'gatsby-remark-smartypants',
         ],

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 const path = require('path');
 const { createFilePath } = require('gatsby-source-filesystem');
 
@@ -95,7 +96,7 @@ exports.createPages = ({ graphql, actions }) => {
 exports.onCreatePage = ({ page, actions }) => {
   const { deletePage, createPage } = actions;
 
-  console.log('onCreatePage ' + page.componentPath);
+  console.log(`onCreatePage ${page.componentPath}`);
   return new Promise(resolve => {
     // if the page component is the index page component
     if (page.componentPath.indexOf('/src/pages/Home/index.js') >= 0) {
@@ -116,9 +117,7 @@ exports.onCreateNode = ({ node, actions, getNode }) => {
 
   if (node.internal.type === 'MarkdownRemark') {
     const { sourceInstanceName, absolutePath } = getNode(node.parent);
-    console.log(
-      '==== onCreateNode ' + sourceInstanceName + ' ---- ' + absolutePath,
-    );
+    console.log(`==== onCreateNode ${sourceInstanceName} ---- ${absolutePath}`);
     const value = createFilePath({ node, getNode });
     createNodeField({
       name: 'slug',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1516,9 +1516,9 @@
       }
     },
     "@hpe/project-scripts": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@hpe/project-scripts/-/project-scripts-1.0.4.tgz",
-      "integrity": "sha512-BZ0a3OoQKjln29Nj78DMmYYcnD8IUpQfO+vFPKBBMejapF9LQKeG7iS7fcULPPt/QbbATrbhIfIPDhrBn03RxA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@hpe/project-scripts/-/project-scripts-1.0.5.tgz",
+      "integrity": "sha512-822gBYQdhK6UJ5JpSn4GMRmjc5xPjE1FnenRpmqnSJ3ObornidJN3PopelD6HvQbfr5yMl7625A/mzMz5S1GyA==",
       "dev": true,
       "requires": {
         "babel-eslint": "^10.0.2",
@@ -1531,84 +1531,6 @@
         "eslint-plugin-react": "^7.14.3",
         "eslint-plugin-react-hooks": "^2.0.1",
         "prettier": "^1.18.2"
-      },
-      "dependencies": {
-        "babel-eslint": {
-          "version": "10.0.3",
-          "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.3.tgz",
-          "integrity": "sha512-z3U7eMY6r/3f3/JB9mTsLjyxrv0Yb1zb8PCWCLpguxfCzBIZUwy23R1t/XKewP+8mEN2Ck8Dtr4q20z6ce6SoA==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "@babel/parser": "^7.0.0",
-            "@babel/traverse": "^7.0.0",
-            "@babel/types": "^7.0.0",
-            "eslint-visitor-keys": "^1.0.0",
-            "resolve": "^1.12.0"
-          }
-        },
-        "eslint-plugin-import": {
-          "version": "2.18.2",
-          "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.18.2.tgz",
-          "integrity": "sha512-5ohpsHAiUBRNaBWAF08izwUGlbrJoJJ+W9/TBwsGoR1MnlgfwMIKrFeSjWbt6moabiXW9xNvtFz+97KHRfI4HQ==",
-          "dev": true,
-          "requires": {
-            "array-includes": "^3.0.3",
-            "contains-path": "^0.1.0",
-            "debug": "^2.6.9",
-            "doctrine": "1.5.0",
-            "eslint-import-resolver-node": "^0.3.2",
-            "eslint-module-utils": "^2.4.0",
-            "has": "^1.0.3",
-            "minimatch": "^3.0.4",
-            "object.values": "^1.1.0",
-            "read-pkg-up": "^2.0.0",
-            "resolve": "^1.11.0"
-          }
-        },
-        "eslint-plugin-react": {
-          "version": "7.14.3",
-          "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.14.3.tgz",
-          "integrity": "sha512-EzdyyBWC4Uz2hPYBiEJrKCUi2Fn+BJ9B/pJQcjw5X+x/H2Nm59S4MJIvL4O5NEE0+WbnQwEBxWY03oUk+Bc3FA==",
-          "dev": true,
-          "requires": {
-            "array-includes": "^3.0.3",
-            "doctrine": "^2.1.0",
-            "has": "^1.0.3",
-            "jsx-ast-utils": "^2.1.0",
-            "object.entries": "^1.1.0",
-            "object.fromentries": "^2.0.0",
-            "object.values": "^1.1.0",
-            "prop-types": "^15.7.2",
-            "resolve": "^1.10.1"
-          },
-          "dependencies": {
-            "doctrine": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-              "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-              "dev": true,
-              "requires": {
-                "esutils": "^2.0.2"
-              }
-            }
-          }
-        },
-        "prettier": {
-          "version": "1.18.2",
-          "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
-          "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
-          "dev": true
-        },
-        "resolve": {
-          "version": "1.12.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
-          "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
-          "dev": true,
-          "requires": {
-            "path-parse": "^1.0.6"
-          }
-        }
       }
     },
     "@jest/console": {
@@ -7038,9 +6960,9 @@
       }
     },
     "eslint-plugin-react-hooks": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.0.1.tgz",
-      "integrity": "sha512-xir+3KHKo86AasxlCV8AHRtIZPHljqCRRUYgASkbatmt0fad4+5GgC7zkT7o/06hdKM6MIwp8giHVXqBPaarHQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.1.2.tgz",
+      "integrity": "sha512-ZR+AyesAUGxJAyTFlF3MbzeVHAcQTFQt1fFVe5o0dzY/HFoj1dgQDMoIkiM+ltN/HhlHBYX4JpJwYonjxsyQMA==",
       "dev": true
     },
     "eslint-scope": {
@@ -7584,6 +7506,14 @@
         "reusify": "^1.0.0"
       }
     },
+    "fault": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.3.tgz",
+      "integrity": "sha512-sfFuP4X0hzrbGKjAUNXYvNqsZ5F6ohx/dZ9I0KQud/aiZNwg263r5L9yGB0clvXHCkzXh5W3t7RSHchggYIFmA==",
+      "requires": {
+        "format": "^0.2.2"
+      }
+    },
     "faye-websocket": {
       "version": "0.11.3",
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
@@ -7851,6 +7781,11 @@
         "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
       }
+    },
+    "format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs="
     },
     "forwarded": {
       "version": "0.1.2",
@@ -10029,9 +9964,9 @@
       "integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ=="
     },
     "handlebars": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.3.tgz",
+      "integrity": "sha512-B0W4A2U1ww3q7VVthTKfh+epHx+q4mCt6iK+zEAzbMBpWQAwxCeKxEGpj/1oQTpzPXDNSOG7hmG14TsISH50yw==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -10344,6 +10279,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
+    },
+    "highlight.js": {
+      "version": "9.13.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.13.1.tgz",
+      "integrity": "sha512-Sc28JNQNDzaH6PORtRLMvif9RSn1mYuOoX3omVjnb0+HbpPygU2ALBI0R/wsiqCb4/fcp07Gdo8g+fhtFrQl6A=="
     },
     "history": {
       "version": "4.9.0",
@@ -13466,6 +13406,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
       "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
+    },
+    "lowlight": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.11.0.tgz",
+      "integrity": "sha512-xrGGN6XLL7MbTMdPD6NfWPwY43SNkjf/d0mecSx/CW36fUZTjRHEq0/Cdug3TWKtRXLWi7iMl1eP0olYxj/a4A==",
+      "requires": {
+        "fault": "^1.0.2",
+        "highlight.js": "~9.13.0"
+      }
     },
     "lpad-align": {
       "version": "1.1.2",
@@ -17384,6 +17333,18 @@
         "prop-types": "^15.5.4"
       }
     },
+    "react-syntax-highlighter": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-11.0.2.tgz",
+      "integrity": "sha512-kqmpM2OH5OodInbEADKARwccwSQWBfZi0970l5Jhp4h39q9Q65C4frNcnd6uHE5pR00W8pOWj9HDRntj2G4Rww==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "highlight.js": "~9.13.0",
+        "lowlight": "~1.11.0",
+        "prismjs": "^1.8.4",
+        "refractor": "^2.4.1"
+      }
+    },
     "react-test-renderer": {
       "version": "16.9.0",
       "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.9.0.tgz",
@@ -17699,6 +17660,37 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",
       "integrity": "sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw=="
+    },
+    "refractor": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/refractor/-/refractor-2.10.0.tgz",
+      "integrity": "sha512-maW2ClIkm9IYruuFYGTqKzj+m31heq92wlheW4h7bOstP+gf8bocmMec+j7ljLcaB1CAID85LMB3moye31jH1g==",
+      "requires": {
+        "hastscript": "^5.0.0",
+        "parse-entities": "^1.1.2",
+        "prismjs": "~1.17.0"
+      },
+      "dependencies": {
+        "hastscript": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-5.1.0.tgz",
+          "integrity": "sha512-7mOQX5VfVs/gmrOGlN8/EDfp1GqV6P3gTNVt+KnX4gbYhpASTM8bklFdFQCbFRAadURXAmw0R1QQdBdqp7jswQ==",
+          "requires": {
+            "comma-separated-tokens": "^1.0.0",
+            "hast-util-parse-selector": "^2.2.0",
+            "property-information": "^5.0.1",
+            "space-separated-tokens": "^1.0.0"
+          }
+        },
+        "property-information": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.3.0.tgz",
+          "integrity": "sha512-IslotQn1hBCZDY7SaJ3zmCjVea219VTwmOk6Pu3z9haU9m4+T8GwaDubur+6NMHEU+Fjs/6/p66z6QULPkcL1w==",
+          "requires": {
+            "xtend": "^4.0.1"
+          }
+        }
+      }
     },
     "regenerate": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -36,13 +36,14 @@
     "react": "^16.9.0",
     "react-dom": "^16.8.6",
     "react-helmet": "^5.2.1",
+    "react-syntax-highlighter": "^11.0.2",
     "redux": "^4.0.4",
     "slate": "^0.47.8",
     "styled-components": "^4.3.2",
     "typescript": "^3.6.2"
   },
   "devDependencies": {
-    "@hpe/project-scripts": "^1.0.4",
+    "@hpe/project-scripts": "^1.0.5",
     "babel-jest": "^24.9.0",
     "babel-preset-gatsby": "^0.2.11",
     "cypress": "^3.4.1",

--- a/src/components/Markdown/index.js
+++ b/src/components/Markdown/index.js
@@ -1,0 +1,91 @@
+import React from 'react';
+import {
+  Anchor,
+  Box,
+  Image as GrommetImage,
+  Markdown as GrommetMarkdown,
+  Paragraph,
+} from 'grommet';
+import { Download, Github } from 'grommet-icons';
+import PropTypes from 'prop-types';
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
+import { dark as codestyle } from 'react-syntax-highlighter/dist/esm/styles/prism';
+
+class Image extends React.Component {
+  render() {
+    const { src } = this.props;
+    if (src === 'Github') {
+      return <Github color="brand" />;
+    }
+    if (src === 'Download') {
+      return <Download color="brand" />;
+    }
+    return <GrommetImage {...this.props} />;
+  }
+}
+
+Image.propTypes = {
+  src: PropTypes.string,
+};
+
+class Code extends React.Component {
+  render() {
+    const { className, children } = this.props;
+    const language = className ? className.substr('lang-'.length) : '';
+
+    if (language) {
+      return (
+        <SyntaxHighlighter language={language} style={codestyle}>
+          {children}
+        </SyntaxHighlighter>
+      );
+    }
+    return <code {...this.props} />;
+  }
+}
+
+Code.propTypes = {
+  className: PropTypes.string,
+  children: PropTypes.node,
+};
+
+const components = {
+  p: {
+    component: Paragraph,
+    props: {
+      size: 'xlarge',
+      style: {
+        maxWidth: '100%',
+      },
+    },
+  },
+  hr: {
+    component: Box,
+    props: {
+      border: {
+        top: 'small',
+        color: 'light-3',
+      },
+    },
+  },
+  img: {
+    component: Image,
+    props: {
+      style: {},
+    },
+  },
+  a: {
+    component: Anchor,
+  },
+  code: {
+    component: Code,
+  },
+};
+
+class Markdown extends React.Component {
+  render() {
+    return <GrommetMarkdown components={components} {...this.props} />;
+  }
+}
+
+export default Markdown;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,25 +1,27 @@
 import BlogCard from './BlogCard';
 import Card from './Card';
 import Content from './Content';
+import Footer from './Footer';
 import Hero from './Hero';
 import Header from './Header';
 import Layout from './Layout';
+import Link from './Link';
+import Markdown from './Markdown';
 import SEO from './Seo';
 import Share from './Share';
 import SocialMedia from './SocialMedia';
-import Link from './Link';
-import Footer from './Footer';
 
 export {
   BlogCard,
   Card,
   Content,
   Footer,
+  Header,
   Hero,
   Layout,
-  SEO,
-  Header,
-  SocialMedia,
-  Share,
   Link,
+  Markdown,
+  SEO,
+  Share,
+  SocialMedia,
 };

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -3,38 +3,10 @@ import { Location } from '@reach/router';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { graphql } from 'gatsby';
-import {
-  Anchor,
-  Box,
-  Heading,
-  Text,
-  Markdown,
-  Paragraph,
-  Image,
-} from 'grommet';
-import { Content, Layout, Link, SEO, Share } from '../components';
-import { useSiteMetadata } from '../hooks/use-site-metadata';
+import { Box, Heading, Text } from 'grommet';
 
-const components = {
-  p: {
-    component: Paragraph,
-    props: {
-      size: 'xlarge',
-      style: {
-        maxWidth: '100%',
-      },
-    },
-  },
-  img: {
-    component: Image,
-    props: {
-      style: {},
-    },
-  },
-  a: {
-    component: Anchor,
-  },
-};
+import { Content, Layout, Markdown, Link, SEO, Share } from '../components';
+import { useSiteMetadata } from '../hooks/use-site-metadata';
 
 // Remove padding or margin from first markdown element.
 // This allows the heading and content to have the same gap.
@@ -83,9 +55,7 @@ function BlogPostTemplate({ data }) {
           </Location>
         </Box>
         <Content margin={{ vertical: 'large' }}>
-          <MarkdownLayout components={components}>
-            {rawMarkdownBody}
-          </MarkdownLayout>
+          <MarkdownLayout>{rawMarkdownBody}</MarkdownLayout>
           {tags && (
             <Box direction="row-responsive" align="baseline" gap="small">
               <Heading level={2} margin={{ vertical: 'none' }}>

--- a/src/templates/platform.js
+++ b/src/templates/platform.js
@@ -2,63 +2,9 @@ import React from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { graphql } from 'gatsby';
-import {
-  Anchor,
-  Box,
-  Heading,
-  Markdown,
-  Paragraph,
-  Image as GrommetImage,
-  Text,
-} from 'grommet';
-import { Github } from 'grommet-icons';
-import { BlogCard, Content, Layout, SEO } from '../components';
+import { Box, Heading, Text } from 'grommet';
+import { BlogCard, Content, Layout, Markdown, SEO } from '../components';
 import { useSiteMetadata } from '../hooks/use-site-metadata';
-
-class Image extends React.Component {
-  render() {
-    const { src } = this.props;
-    return src === 'Github' ? (
-      <Github color="brand" />
-    ) : (
-      <GrommetImage {...this.props} />
-    );
-  }
-}
-
-Image.propTypes = {
-  src: PropTypes.string.isRequired,
-};
-
-const components = {
-  p: {
-    component: Paragraph,
-    props: {
-      size: 'xlarge',
-      style: {
-        maxWidth: '100%',
-      },
-    },
-  },
-  img: {
-    component: Image,
-    props: {
-      style: {},
-    },
-  },
-  hr: {
-    component: Box,
-    props: {
-      border: {
-        top: 'small',
-        color: 'light-3',
-      },
-    },
-  },
-  a: {
-    component: Anchor,
-  },
-};
 
 // Remove padding or margin from first markdown element.
 // This allows the heading and content to have the same gap.
@@ -87,9 +33,7 @@ function PlatformTemplate({ data }) {
           </Box>
           <Content gap="medium" width="xlarge" margin={{ vertical: 'large' }}>
             <Text size="xlarge">{description}</Text>
-            <MarkdownLayout components={components}>
-              {rawMarkdownBody}
-            </MarkdownLayout>
+            <MarkdownLayout>{rawMarkdownBody}</MarkdownLayout>
           </Content>
         </Box>
         <Box flex={false} direction="row-responsive" wrap>
@@ -124,6 +68,24 @@ PlatformTemplate.propTypes = {
         description: PropTypes.string,
       }).isRequired,
     }).isRequired,
+    allMarkdownRemark: PropTypes.shape({
+      edges: PropTypes.arrayOf(
+        PropTypes.shape({
+          node: PropTypes.shape({
+            frontmatter: PropTypes.shape({
+              title: PropTypes.string.isRequired,
+              author: PropTypes.string,
+              date: PropTypes.string,
+            }).isRequired,
+            excerpt: PropTypes.string.isRequired,
+            fields: PropTypes.shape({
+              slug: PropTypes.string.isRequired,
+              sourceInstanceName: PropTypes.string.isRequired,
+            }),
+          }).isRequired,
+        }),
+      ),
+    }),
   }).isRequired,
 };
 


### PR DESCRIPTION
This adds  Prismjs markdown styling to `<code>` blocks in the blogs and platform docs.
The code styling is done via some css still but the rest of the Markdown is styled by grommet components. For now I just picked an existing dark CSS for the `<code>` until we settle on something.

Note that some of the markdown content files still don't render code blocks correctly since Grommet's Markdown component seems to expect a blank line before the **\`\`\`language**  lines and some of the checked in content doesn't put a blank line before them yet.

See /blog/2018-02-01-using-hpe-onesphere-javascript-package/ as an example of working formatting