### PR TITLE
redirect events page to platform for testing

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,10 +6,11 @@
 
   ## Uncomment to use this redirect for Single Page Applications like create-react-app. 
   ## Not needed for static site generators.
-  #[[redirects]]
-  #  from = "/*"
-  #  to = "/index.html"
-  #  status = 200
+[[redirects]]
+  from = "/events"
+  to = "/platform"
+  status = 301
+  force = false
   
   ## (optional) Settings for Netlify Dev
   ## https://github.com/netlify/netlify-dev-plugin#project-detection

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,2 +1,2 @@
 /blog/EEVLz2X9vmSmZg6k6Dqx/end-to-end-machine-learning-using-containerization /blog/end-to-end-machine-learning-using-containerization
-/events /platform
+/events     /platform       301

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,1 +1,2 @@
 /blog/EEVLz2X9vmSmZg6k6Dqx/end-to-end-machine-learning-using-containerization /blog/end-to-end-machine-learning-using-containerization
+/events /platform


### PR DESCRIPTION
This PR redirects the events page to the platform page for testing the Netlify redirect functionality.