### PR TITLE
Fixed Safari card of upcoming  events

### DIFF
--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -113,13 +113,20 @@ export const Card = ({ category, content, width = 'medium', link, image }) => (
       >
         <CardHeader
           justify="end"
+          align="end"
           pad={{ vertical: 'small', horizontal: 'medium' }}
+          direction="column"
         >
           <Text color="text-weak">{category}</Text>
+          {size === 'small' && image && (
+            <Box gridArea="image" alignSelf="center">
+              {image && <Image src={image} />}
+            </Box>
+          )}
         </CardHeader>
         <BodyLayout width={width}>
-          {image && (
-            <Box gridArea="image" align="start" fill="horizontal">
+          {size !== 'small' && image && (
+            <Box gridArea="image" align="start">
               {image && <Image src={image} />}
             </Box>
           )}


### PR DESCRIPTION
Fixed the Upcoming Events layout issue on Safari

Before the fix (right) After (left)
![image](https://user-images.githubusercontent.com/6320236/109557735-b88e9580-7a95-11eb-881a-24bd7c8e97d4.png)

Related to #137 