### PR TITLE
Add site url and cms logo

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -5,7 +5,11 @@ backend:
  open_authoring: true
 
 publish_mode: editorial_workflow
-
+# site_url: https://developer.hpe.com/
+# display_url: https://developer.hpe.com/
+site_url: https://hpe-dev-portal.netlify.app/
+display_url: https://hpe-dev-portal.netlify.app/
+logo_url: /img/hpedev.png
 
 media_folder: static/img
 public_folder: /img


### PR DESCRIPTION
This PR adds the HPE DEV logo to CMS and site URL in the CMS top right corner for easy site navigation.