### PR TITLE
Add bash script to remove hostname from blog url

### DIFF
--- a/remove-blog-hostname.sh
+++ b/remove-blog-hostname.sh
@@ -1,0 +1,3 @@
+#! /bin/sh
+
+grep -rl 'https://developer.hpe.com/blog' ./content/blog | xargs sed -i '' -e 's,https://developer.hpe.com/blog,/blog,g'


### PR DESCRIPTION
A bash script to remove hostname from blog url. This script was used for this pr https://github.com/hpe-dev-incubator/hpe-dev-portal/pull/331

**To Use:**
Run `bash remove-blog-hostname.sh` in `hpe-dev-portal` root folder