### PR TITLE
Platform Page - should take user back to the same spot after clicking on a Platform card

### DIFF
--- a/src/components/BlogCard/index.js
+++ b/src/components/BlogCard/index.js
@@ -42,7 +42,7 @@ export const BlogCard = ({ node, ...rest }) => (
         ? (e) => {
             navigate(`/${node.fields.sourceInstanceName}${node.fields.slug}`);
             localStorage.setItem(
-              'position',
+              'blogPosition',
               JSON.stringify(e.nativeEvent.pageY - e.nativeEvent.clientY),
             );
           }

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -17,7 +17,12 @@ function Header() {
       label="Open Source"
       to="https://www.hpe.com/us/en/open-source.html"
     />,
-    <ButtonLink key="pl" label="Platforms" to="/platforms" />,
+    <ButtonLink
+      key="pl"
+      label="Platforms"
+      to="/platforms"
+      state={{ state: { isPlatformHeaderClicked: true } }}
+    />,
     <ButtonLink key="ev" label="Events" to="/events" />,
     <ButtonLink key="su" label="Skill Up" to="/skillup" />,
     <ButtonLink

--- a/src/components/PlatformCard/index.js
+++ b/src/components/PlatformCard/index.js
@@ -8,7 +8,17 @@ const PlatformCard = ({ description, link, image, title }) => (
     elevation="medium"
     pad="large"
     gap="large"
-    onClick={link ? () => navigate(link) : undefined}
+    onClick={
+      link
+        ? (e) => {
+            navigate(link);
+            localStorage.setItem(
+              'platformPosition',
+              JSON.stringify(e.nativeEvent.pageY - e.nativeEvent.clientY),
+            );
+          }
+        : undefined
+    }
   >
     <Box direction="row-responsive" gap="large" align="center">
       <Box flex>

--- a/src/pages/blog/index.js
+++ b/src/pages/blog/index.js
@@ -50,7 +50,7 @@ function Blog({ data, location }) {
       navigate('/blog', { replace: true });
       setLatestPage(initialPage);
       setBlogPosts(initialPage.nodes);
-      localStorage.clear();
+      localStorage.removeItem('blogPosition');
     }
   }, [initialPage, location]);
 

--- a/src/pages/blog/index.js
+++ b/src/pages/blog/index.js
@@ -55,7 +55,7 @@ function Blog({ data, location }) {
   }, [initialPage, location]);
 
   useEffect(() => {
-    const scrollPosition = JSON.parse(localStorage.getItem('position'));
+    const scrollPosition = JSON.parse(localStorage.getItem('blogPosition'));
 
     if (scrollPosition) {
       setTimeout(() => {

--- a/src/pages/platforms/index.js
+++ b/src/pages/platforms/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { graphql } from 'gatsby';
 import { Heading, Paragraph } from 'grommet';
@@ -35,6 +35,16 @@ function Platform({ data }) {
   const platforms = data.allMarkdownRemark.edges;
   const siteMetadata = useSiteMetadata();
   const siteTitle = siteMetadata.title;
+
+  useEffect(() => {
+    const scrollPosition = JSON.parse(localStorage.getItem('platformPosition'));
+
+    if (scrollPosition) {
+      setTimeout(() => {
+        window.scrollTo({ top: scrollPosition, left: 0, behavior: 'smooth' });
+      }, 100);
+    }
+  }, []);
 
   return (
     <Layout title={siteTitle}>

--- a/src/pages/platforms/index.js
+++ b/src/pages/platforms/index.js
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { graphql } from 'gatsby';
+import { graphql, navigate } from 'gatsby';
 import { Heading, Paragraph } from 'grommet';
 
 import {
@@ -38,6 +38,7 @@ function Platform({ data, location }) {
 
   useEffect(() => {
     if (location.state && location.state.isPlatformHeaderClicked) {
+      navigate('/platforms', { replace: true });
       localStorage.removeItem('platformPosition');
     }
   }, [location]);

--- a/src/pages/platforms/index.js
+++ b/src/pages/platforms/index.js
@@ -31,10 +31,16 @@ const rows = {
   xlarge: ['auto'],
 };
 
-function Platform({ data }) {
+function Platform({ data, location }) {
   const platforms = data.allMarkdownRemark.edges;
   const siteMetadata = useSiteMetadata();
   const siteTitle = siteMetadata.title;
+
+  useEffect(() => {
+    if (location.state && location.state.isPlatformHeaderClicked) {
+      localStorage.removeItem('platformPosition');
+    }
+  }, [location]);
 
   useEffect(() => {
     const scrollPosition = JSON.parse(localStorage.getItem('platformPosition'));
@@ -103,6 +109,11 @@ Platform.propTypes = {
       ).isRequired,
     }).isRequired,
   }).isRequired,
+  location: PropTypes.shape({
+    state: PropTypes.shape({
+      isPlatformHeaderClicked: PropTypes.bool,
+    }),
+  }),
 };
 
 export default Platform;

--- a/src/templates/platform.js
+++ b/src/templates/platform.js
@@ -81,7 +81,7 @@ function PlatformTemplate({ data }) {
           <ButtonLink
             icon={<FormPreviousLink />}
             label="Go to Platforms Page"
-            to="/platform"
+            to="/platforms"
           />
         </Box>
       </Box>


### PR DESCRIPTION
## Issue
Issue: https://github.com/hpe-dev-incubator/hpe-dev-portal/issues/359
When a user selects a Platform Card which will take them to the specific Platform page, then goes back to the Platform page, they will be automatically taken to the top of the Platform page. 

## Proposed Changes - What does this PR add/edit/remove to achieve its purpose
- Saves Platform page position to localStorage when a platform card is clicked
- When user goes back to Platform page either by clicking back browser or "Go to Platform Page", the page component will check local storage if scroll position is saved
- Clicking on Platform from header will clear localStorage scroll position for Platform Page


## Tests
<!-- Instructions to test and confirm the changes the pull requests intends to implement.
The steps should be simple enough so that someone with no knowledge should be able to perform these tests. -->
### Test back button browser
1. Go to Platform page
2. Click on Platform card
3. When you are on the selected Platform Card page, click the browser back button to go back
4. You should be taken to the same spot that you were perviously on in the Platform page

### Test **Go to Platform Page**
1. Go to Platform page
2. Click on Platform card
3. When you are on the Platform Post page, scroll down to the bottom and click on **Go to Platform Page**
4. You should be taken to the same spot that you were perviously on in the Platform page

### Test **Platform** on the Header
1. On any page other than Blog page, click on the **Platform** button on the Header Navigation
2. You should be taken to the top of the Platform page



