### PR TITLE
Platform Page - should take user back to the same spot after clicking on a Platform card 

### DIFF
--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -31,7 +31,12 @@ function Header() {
       to="/blog"
       state={{ state: { isBlogHeaderClicked: true } }}
     />,
-    <ButtonLink key="nw" label="Newsletter" to="/newsletter-signup" />,
+    <ButtonLink
+      key="nw"
+      label="Newsletter"
+      to="/newsletter-signup"
+      state={{ state: { isNewsletterHeaderClicked: true } }}
+    />,
     <ButtonLink key="cm" label="Community" to="/community" />,
   ];
 

--- a/src/components/OpenSourceCard/index.js
+++ b/src/components/OpenSourceCard/index.js
@@ -30,7 +30,7 @@ const OpenSourceCard = ({
         ? (e) => {
             navigate(link);
             localStorage.setItem(
-              'newsletter',
+              'newsletterData',
               JSON.stringify({
                 index,
                 position: e.nativeEvent.pageY - e.nativeEvent.clientY,

--- a/src/components/OpenSourceCard/index.js
+++ b/src/components/OpenSourceCard/index.js
@@ -92,7 +92,7 @@ OpenSourceCard.propTypes = {
   stars: PropTypes.bool,
   monthly: PropTypes.number,
   newsletter: PropTypes.bool,
-  index: PropTypes.number
+  index: PropTypes.number,
 };
 
 export default OpenSourceCard;

--- a/src/components/OpenSourceCard/index.js
+++ b/src/components/OpenSourceCard/index.js
@@ -20,11 +20,25 @@ const OpenSourceCard = ({
   date,
   monthly,
   newsletter,
+  index,
 }) => (
   <GrommetCard
     pad="large"
     elevation="medium"
-    onClick={link ? () => navigate(link) : undefined}
+    onClick={
+      link
+        ? (e) => {
+            navigate(link);
+            localStorage.setItem(
+              'newsletter',
+              JSON.stringify({
+                index,
+                position: e.nativeEvent.pageY - e.nativeEvent.clientY,
+              }),
+            );
+          }
+        : undefined
+    }
   >
     <CardHeader justify="between" pad={{ top: 'none', bottom: 'medium' }}>
       {date && (
@@ -78,6 +92,7 @@ OpenSourceCard.propTypes = {
   stars: PropTypes.bool,
   monthly: PropTypes.number,
   newsletter: PropTypes.bool,
+  index: PropTypes.number
 };
 
 export default OpenSourceCard;

--- a/src/pages/blog/index.js
+++ b/src/pages/blog/index.js
@@ -34,9 +34,13 @@ function Blog({ data, location }) {
   useEffect(() => {
     setCollectionId(initialPage.collection.id);
 
-    const blogLocalStorage = JSON.parse(localStorage.getItem('blogData'),);
+    const blogLocalStorage = JSON.parse(localStorage.getItem('blogData'));
 
-    if (blogLocalStorage && blogLocalStorage.latestPage && blogLocalStorage.latestBlogPosts) {
+    if (
+      blogLocalStorage &&
+      blogLocalStorage.latestPage &&
+      blogLocalStorage.latestBlogPosts
+    ) {
       setLatestPage(blogLocalStorage.latestPage);
       setBlogPosts(blogLocalStorage.latestBlogPosts);
     }
@@ -46,7 +50,7 @@ function Blog({ data, location }) {
       setLatestPage(initialPage);
       setBlogPosts(initialPage.nodes);
       localStorage.removeItem('blogPosition');
-      localStorage.removeItem('blogData')
+      localStorage.removeItem('blogData');
     }
   }, [initialPage, location]);
 
@@ -72,9 +76,11 @@ function Blog({ data, location }) {
     setBlogPosts((state) => [...state, ...json.nodes]);
     setLatestPage(json);
 
-    localStorage.setItem('blogData', JSON.stringify({
+    localStorage.setItem(
+      'blogData',
+      JSON.stringify({
         latestBlogPosts: [...blogPosts, ...json.nodes],
-        latestPage: (json),
+        latestPage: json,
       }),
     );
   }, [latestPage, collectionId, blogPosts]);

--- a/src/pages/blog/index.js
+++ b/src/pages/blog/index.js
@@ -34,16 +34,11 @@ function Blog({ data, location }) {
   useEffect(() => {
     setCollectionId(initialPage.collection.id);
 
-    const localStorageLatestPage = JSON.parse(
-      localStorage.getItem('latestPage'),
-    );
-    const localStorageLatestBlogPosts = JSON.parse(
-      localStorage.getItem('latestBlogPosts'),
-    );
+    const blogLocalStorage = JSON.parse(localStorage.getItem('blogData'),);
 
-    if (localStorageLatestPage && localStorageLatestBlogPosts) {
-      setLatestPage(localStorageLatestPage);
-      setBlogPosts(localStorageLatestBlogPosts);
+    if (blogLocalStorage && blogLocalStorage.latestPage && blogLocalStorage.latestBlogPosts) {
+      setLatestPage(blogLocalStorage.latestPage);
+      setBlogPosts(blogLocalStorage.latestBlogPosts);
     }
 
     if (location.state && location.state.isBlogHeaderClicked) {
@@ -51,6 +46,7 @@ function Blog({ data, location }) {
       setLatestPage(initialPage);
       setBlogPosts(initialPage.nodes);
       localStorage.removeItem('blogPosition');
+      localStorage.removeItem('blogData')
     }
   }, [initialPage, location]);
 
@@ -76,11 +72,11 @@ function Blog({ data, location }) {
     setBlogPosts((state) => [...state, ...json.nodes]);
     setLatestPage(json);
 
-    localStorage.setItem(
-      'latestBlogPosts',
-      JSON.stringify([...blogPosts, ...json.nodes]),
+    localStorage.setItem('blogData', JSON.stringify({
+        latestBlogPosts: [...blogPosts, ...json.nodes],
+        latestPage: (json),
+      }),
     );
-    localStorage.setItem('latestPage', JSON.stringify(json));
   }, [latestPage, collectionId, blogPosts]);
 
   return (

--- a/src/pages/newsletter-signup/index.js
+++ b/src/pages/newsletter-signup/index.js
@@ -1,6 +1,6 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { graphql } from 'gatsby';
+import { graphql, navigate } from 'gatsby';
 import { Box, Tab, Tabs, Heading } from 'grommet';
 import {
   Layout,
@@ -25,8 +25,7 @@ const rows = {
   large: ['auto'],
   xlarge: ['auto'],
 };
-
-function NewsletterSignup({ data }) {
+function NewsletterSignup({ data, location }) {
   const newsletters = data.allMarkdownRemark.group.sort((a, b) =>
     a.fieldValue < b.fieldValue ? 1 : -1,
   );
@@ -34,6 +33,32 @@ function NewsletterSignup({ data }) {
   const onActive = (nextIndex) => setIndex(nextIndex);
   const siteMetadata = useSiteMetadata();
   const siteTitle = siteMetadata.title;
+
+  useEffect(() => {
+    if (location.state && location.state.isNewsletterHeaderClicked) {
+      navigate('/newsletter-signup', { replace: true });
+      localStorage.removeItem('newsletter');
+    }
+  }, [location]);
+
+  useEffect(() => {
+    const newsletterLocalStorage = JSON.parse(
+      localStorage.getItem('newsletter')
+    );
+
+    if (newsletterLocalStorage && newsletterLocalStorage.index) {
+      setIndex(newsletterLocalStorage.index);
+    }
+    if (newsletterLocalStorage && newsletterLocalStorage.position) {
+      setTimeout(() => {
+        window.scrollTo({
+          top: newsletterLocalStorage.position,
+          left: 0,
+          behavior: 'smooth',
+        });
+      }, 100);
+    }
+  }, []);
 
   return (
     <Layout title={siteTitle}>
@@ -72,6 +97,7 @@ function NewsletterSignup({ data }) {
                     date={node.frontmatter.date}
                     monthly={node.frontmatter.monthly}
                     newsletter
+                    index={index}
                   />
                 ))}
               </ResponsiveGrid>
@@ -108,6 +134,11 @@ NewsletterSignup.propTypes = {
       ).isRequired,
     }).isRequired,
   }).isRequired,
+  location: PropTypes.shape({
+    state: PropTypes.shape({
+      isNewsletterHeaderClicked: PropTypes.bool,
+    }),
+  }),
 };
 
 export default NewsletterSignup;

--- a/src/pages/newsletter-signup/index.js
+++ b/src/pages/newsletter-signup/index.js
@@ -43,7 +43,7 @@ function NewsletterSignup({ data, location }) {
 
   useEffect(() => {
     const newsletterLocalStorage = JSON.parse(
-      localStorage.getItem('newsletter')
+      localStorage.getItem('newsletter'),
     );
 
     if (newsletterLocalStorage && newsletterLocalStorage.index) {

--- a/src/pages/newsletter-signup/index.js
+++ b/src/pages/newsletter-signup/index.js
@@ -37,13 +37,13 @@ function NewsletterSignup({ data, location }) {
   useEffect(() => {
     if (location.state && location.state.isNewsletterHeaderClicked) {
       navigate('/newsletter-signup', { replace: true });
-      localStorage.removeItem('newsletter');
+      localStorage.removeItem('newsletterData');
     }
   }, [location]);
 
   useEffect(() => {
     const newsletterLocalStorage = JSON.parse(
-      localStorage.getItem('newsletter'),
+      localStorage.getItem('newsletterData'),
     );
 
     if (newsletterLocalStorage && newsletterLocalStorage.index) {


### PR DESCRIPTION
## Issue
Issue: https://github.com/hpe-dev-incubator/hpe-dev-portal/issues/360
When a user selects a Newsletter Card which will take them to the specific Newsletter page, then goes back to the Newsletter page, they will be automatically taken to the top of the Newsletter page. 

## Proposed Changes - What does this PR add/edit/remove to achieve its purpose
- Saves Newsletter page position and tab index/year to localStorage when a Newsletter card is clicked
- When user goes back to Newsletter page either by clicking back browser, the page component will check local storage if scroll position and tab index/year is saved
- Clicking on Newsletter from header will clear localStorage scroll position and tab index/year for Newsletter Page
- In the Blogs page, I consolidated the `latestBlogPosts` and `latestPage` values as an object in `blogData` to better organize localStorage naming between Blog, Platform, and Newsletter pages https://github.com/hpe-dev-incubator/hpe-dev-portal/pull/365/files#diff-f3ff5ef15389e9dc360a554de5d6a1d3243d1407e107c8c462c5c01350eb5be3R80-R84

## Tests
<!-- Instructions to test and confirm the changes the pull requests intends to implement.
The steps should be simple enough so that someone with no knowledge should be able to perform these tests. -->
### Test back button browser
1. Go to Newsletter page
2. Click on Newsletter card
3. When you are on the selected Newsletter Card page, click the browser back button to go back
4. You should be taken to the same spot that you were perviously on in the Newsletter page

### Test **Newsletter** on the Header
1. On any page other than Blog page, click on the **Newsletter** button on the Header Navigation
2. You should be taken to the top of the Newsletter page



