### PR TITLE
remove the time stamp from blog slug

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -73,7 +73,7 @@ collections:
     extension: 'md'
     create: true
     publish: false
-    slug: '{{year}}-{{month}}-{{day}}-{{slug}}'
+    slug: '{{slug}}'
     editor:
       preview: true
     fields:


### PR DESCRIPTION
This PR removes the time stamp added to the blog slug.

**Before:** /blog/2021-04-15-test-blog-to-check-the-date-in-blog-url/

**Now:** /blog/test-blog-to-check-the-date-in-blog-url/