### PR TITLE
Issue 439 - Portrait image looks grainy at 96px

### DIFF
--- a/src/components/BlogCard/index.js
+++ b/src/components/BlogCard/index.js
@@ -53,8 +53,8 @@ export const BlogCard = ({ node, ...rest }) => (
       <Box align="start">
         {(node.authorimage || node.frontmatter.authorimage) && (
           <Image
-            width='96px'
-            height='96px'
+            width="96px"
+            height="96px"
             src={node.authorimage || node.frontmatter.authorimage}
             alt="author logo"
           />
@@ -126,8 +126,8 @@ export const FeaturedBlogCard = ({ node, ...rest }) => (
       >
         <Box align="start" direction="row" gap="small">
           <Image
-            width='96px'
-            height='96px'
+            width="96px"
+            height="96px"
             src={node.frontmatter.authorimage}
             alt="author logo"
           />

--- a/src/components/BlogCard/index.js
+++ b/src/components/BlogCard/index.js
@@ -53,6 +53,8 @@ export const BlogCard = ({ node, ...rest }) => (
       <Box align="start">
         {(node.authorimage || node.frontmatter.authorimage) && (
           <Image
+            width='96px'
+            height='96px'
             src={node.authorimage || node.frontmatter.authorimage}
             alt="author logo"
           />
@@ -124,7 +126,8 @@ export const FeaturedBlogCard = ({ node, ...rest }) => (
       >
         <Box align="start" direction="row" gap="small">
           <Image
-            fit="contain"
+            width='96px'
+            height='96px'
             src={node.frontmatter.authorimage}
             alt="author logo"
           />


### PR DESCRIPTION
Issue #439 
- Sets blog card image to 96px x 96px
- Contributors will need to upload a 192px x 192px image for `authorimage`

**Testing**
- Add this sample 196px image in `<img src=` https://i.picsum.photos/id/217/196/196.jpg?hmac=RgbJHbjIs0Yd17h9DwEK5jMX8mRelTukejfvntw5n4s
