### PR TITLE
Add open graph tag for blog image

### DIFF
--- a/src/components/Seo/index.js
+++ b/src/components/Seo/index.js
@@ -11,7 +11,7 @@ import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
 import { useSiteMetadata } from '../../hooks/use-site-metadata';
 
-function SEO({ description, lang, meta, title }) {
+function SEO({ description, lang, meta, title, image }) {
   const siteMetadata = useSiteMetadata();
   const metaDescription = description || siteMetadata.description;
 
@@ -34,6 +34,10 @@ function SEO({ description, lang, meta, title }) {
         {
           property: 'og:description',
           content: metaDescription,
+        },
+        {
+          property: 'og:image',
+          content: image,
         },
         {
           property: 'og:type',
@@ -74,6 +78,7 @@ SEO.propTypes = {
   lang: PropTypes.string,
   meta: PropTypes.arrayOf(PropTypes.object),
   title: PropTypes.string.isRequired,
+  image: PropTypes.string,
 };
 
 export default SEO;

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -57,15 +57,17 @@ const findImageURL = (body) => {
   }
 
   // Find image url by tag
-  const element = document.createElement('div');
-  element.innerHTML = body;
-  const foundByImageTag = element.querySelector('img');
-  if (foundByImageTag) {
-    console.log('foundByImageTag: ', foundByImageTag.src);
-    const imageURL = foundByImageTag.src.includes('https://')
-      ? foundByImageTag
-      : `https://developer.hpe.com${foundByImageTag.getAttribute('src')}`;
-    return imageURL;
+  if (typeof document !== 'undefined') {
+    const element = document.createElement('div');
+    element.innerHTML = body;
+    const foundByImageTag = element.querySelector('img');
+    if (foundByImageTag) {
+      console.log('foundByImageTag: ', foundByImageTag.src);
+      const imageURL = foundByImageTag.src.includes('https://')
+        ? foundByImageTag
+        : `https://developer.hpe.com${foundByImageTag.getAttribute('src')}`;
+      return imageURL;
+    }
   }
 
   return null;

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -44,6 +44,33 @@ const rows = {
   xlarge: ['auto'],
 };
 
+const findImageURL = (body) => {
+  // Find image url by Regex
+  const foundByRegex = /!\[[^\]]*\]\((?<filename>.*?)(?="|\))(?<optionalpart>".*")?\)/gi.exec(
+    body,
+  );
+  if (foundByRegex) {
+    const imageURL = foundByRegex[1].includes('https://')
+      ? foundByRegex[1]
+      : `https://developer.hpe.com${foundByRegex[1]}`;
+    return imageURL;
+  }
+
+  // Find image url by tag
+  const element = document.createElement('div');
+  element.innerHTML = body;
+  const foundByImageTag = element.querySelector('img');
+  if (foundByImageTag) {
+    console.log('foundByImageTag: ', foundByImageTag.src);
+    const imageURL = foundByImageTag.src.includes('https://')
+      ? foundByImageTag
+      : `https://developer.hpe.com${foundByImageTag.getAttribute('src')}`;
+    return imageURL;
+  }
+
+  return null;
+};
+
 function BlogPostTemplate({ data }) {
   const { post } = data;
   const blogsByTags = data.blogsByTags.edges;
@@ -66,7 +93,11 @@ function BlogPostTemplate({ data }) {
 
   return (
     <Layout title={siteTitle}>
-      <SEO title={title} description={description || excerpt} />
+      <SEO
+        title={title}
+        description={description || excerpt}
+        image={findImageURL(rawMarkdownBody)}
+      />
       <Box flex overflow="auto" gap="medium" pad="small">
         <Box direction="row-responsive">
           <Box pad={{ vertical: 'large', horizontal: 'medium' }} align="center">


### PR DESCRIPTION
## Issue
Issue: https://github.com/hpe-dev-incubator/hpe-dev-portal/issues/427
Meta tag with property `og:image` property does not display  

## Proposed Changes - What does this PR add/edit/remove to achieve its purpose
- Gets the first image in `rawMarkdownbody` then will set the `og:image` property
- From research, I found that an image url is written 3 ways in the `rawMarkdownbody`:
  - `![](/img/shimi-yacobi-375.jpg)` https://developer.hpe.com/blog/meet-open-source-grommet-lead-developer-and-architect-shimrit-yacobi/
  - `<img src="/img/full-reveal-top-of-page-image1.jpg" width="800" height="453">` https://developer.hpe.com/blog/new-look-new-brains-all-the-tools/
  - `[![HackShack]( https://hpe-developer-portal.s3.amazonaws.com/uploads/media/2021/4/hackshack-1617960622993.png)]( https://hackshack.hpedev.io/workshops)` https://developer.hpe.com/blog/from-jupyter-notebooks-as-a-service-to-hpe-dev-workshops-on-demand/
  - The function `findImageByURL` will be able to find the image urls above by either Regex or image tag


## Tests
<!-- Instructions to test and confirm the changes the pull requests intends to implement.
The steps should be simple enough so that someone with no knowledge should be able to perform these tests. -->

Try testing with the following validators:
- https://www.heymeta.com/
- https://developers.facebook.com/tools/debug/
- https://cards-dev.twitter.com/validator



