### PR TITLE
Fix Event card issue when updated to Safari 14.1

### DIFF
--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -88,7 +88,14 @@ const bases = {
   large: '2/3',
 };
 
-export const Card = ({ category, content, width = 'medium', link, image, source }) => (
+export const Card = ({
+  category,
+  content,
+  width = 'medium',
+  link,
+  image,
+  source,
+}) => (
   <ResponsiveContext.Consumer>
     {(size) => (
       <GrommetCard

--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -88,14 +88,14 @@ const bases = {
   large: '2/3',
 };
 
-export const Card = ({ category, content, width = 'medium', link, image }) => (
+export const Card = ({ category, content, width = 'medium', link, image, source }) => (
   <ResponsiveContext.Consumer>
     {(size) => (
       <GrommetCard
         elevation="medium"
         margin="medium"
         flex="grow"
-        basis={size === 'small' ? 'auto' : bases[width]}
+        basis={size === 'small' || source === 'event' ? 'auto' : bases[width]}
         /* eslint-disable */
         onClick={
           link && link.match(/^\//g)

--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -94,7 +94,7 @@ export const Card = ({
   width = 'medium',
   link,
   image,
-  source,
+  ...rest
 }) => (
   <ResponsiveContext.Consumer>
     {(size) => (
@@ -102,7 +102,8 @@ export const Card = ({
         elevation="medium"
         margin="medium"
         flex="grow"
-        basis={size === 'small' || source === 'event' ? 'auto' : bases[width]}
+        basis={size === 'small' ? 'auto' : bases[width]}
+        {...rest}
         /* eslint-disable */
         onClick={
           link && link.match(/^\//g)

--- a/src/pages/events/index.js
+++ b/src/pages/events/index.js
@@ -73,7 +73,7 @@ function Events({ data }) {
       )}
       {upcomingEvents && upcomingEvents.length > 0 && (
         <SectionHeader title="Upcoming Events">
-          {upcomingEvents.map(({ node }) => (
+          {upcomingEvents.map(({ node }) =>  (
             <Card
               key={node.id}
               category={node.frontmatter.category}
@@ -81,6 +81,7 @@ function Events({ data }) {
               content={node.rawMarkdownBody}
               link={node.frontmatter.link}
               image={node.frontmatter.image}
+              source={node.fields.sourceInstanceName}
             />
           ))}
         </SectionHeader>

--- a/src/pages/events/index.js
+++ b/src/pages/events/index.js
@@ -81,7 +81,6 @@ function Events({ data }) {
               content={node.rawMarkdownBody}
               link={node.frontmatter.link}
               image={node.frontmatter.image}
-              source={node.fields.sourceInstanceName}
               basis="auto"
             />
           ))}

--- a/src/pages/events/index.js
+++ b/src/pages/events/index.js
@@ -82,6 +82,7 @@ function Events({ data }) {
               link={node.frontmatter.link}
               image={node.frontmatter.image}
               source={node.fields.sourceInstanceName}
+              basis="auto"
             />
           ))}
         </SectionHeader>

--- a/src/pages/events/index.js
+++ b/src/pages/events/index.js
@@ -73,7 +73,7 @@ function Events({ data }) {
       )}
       {upcomingEvents && upcomingEvents.length > 0 && (
         <SectionHeader title="Upcoming Events">
-          {upcomingEvents.map(({ node }) =>  (
+          {upcomingEvents.map(({ node }) => (
             <Card
               key={node.id}
               category={node.frontmatter.category}


### PR DESCRIPTION
## Issue
Issue: Event card expanded outside of parent container each taking `basis="2/3"` of the main container. 
![May-12-2021 15-40-10](https://user-images.githubusercontent.com/11492092/118298859-e5e3c080-b494-11eb-8e24-0d984075be5e.gif)

## Proposed Changes 
Add extra conditional in the Card component to check if `source === 'event'`. If true, then set basis to `auto`.

## Test
- Install Big Sur 11.3.1 then Safari should update automatically to 14. 1
