### PR TITLE
Fix markdown inline code style

### DIFF
--- a/src/components/Markdown/index.js
+++ b/src/components/Markdown/index.js
@@ -13,8 +13,8 @@ import {
 import { Download, Github } from 'grommet-icons';
 import PropTypes from 'prop-types';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
-import { a11yDark as codestyle } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { deepMerge } from 'grommet/utils';
+import codestyle from './markdownTheme';
 
 class Image extends React.Component {
   render() {
@@ -45,7 +45,7 @@ class Code extends React.Component {
         </SyntaxHighlighter>
       );
     }
-    return <code {...this.props} />;
+    return <code style={codestyle.code} {...this.props} />;
   }
 }
 

--- a/src/components/Markdown/markdownTheme.js
+++ b/src/components/Markdown/markdownTheme.js
@@ -1,0 +1,155 @@
+export default {
+  'code[class*="language-"]': {
+    color: '#f8f8f2',
+    background: 'none',
+    fontFamily: "Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace",
+    textAlign: 'left',
+    whiteSpace: 'pre',
+    wordSpacing: 'normal',
+    wordBreak: 'normal',
+    wordWrap: 'normal',
+    lineHeight: '1.5',
+    MozTabSize: '4',
+    OTabSize: '4',
+    tabSize: '4',
+    WebkitHyphens: 'none',
+    MozHyphens: 'none',
+    msHyphens: 'none',
+    hyphens: 'none',
+  },
+  'pre[class*="language-"]': {
+    color: '#f8f8f2',
+    background: '#2b2b2b',
+    fontFamily: "Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace",
+    textAlign: 'left',
+    whiteSpace: 'pre',
+    wordSpacing: 'normal',
+    wordBreak: 'normal',
+    wordWrap: 'normal',
+    lineHeight: '1.5',
+    MozTabSize: '4',
+    OTabSize: '4',
+    tabSize: '4',
+    WebkitHyphens: 'none',
+    MozHyphens: 'none',
+    msHyphens: 'none',
+    hyphens: 'none',
+    padding: '1em',
+    margin: '0.5em 0',
+    overflow: 'auto',
+    borderRadius: '0.3em',
+  },
+  ':not(pre) > code[class*="language-"]': {
+    background: '#2b2b2b',
+    padding: '0.1em',
+    borderRadius: '0.3em',
+    whiteSpace: 'normal',
+  },
+  code: {
+    color: '#f8f8f2',
+    background: '#2b2b2b',
+    fontFamily: "Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace",
+    padding: '0.1em',
+    borderRadius: '0.3em',
+    whiteSpace: 'nowrap',
+    fontSize: '18px',
+  },
+  comment: {
+    color: '#d4d0ab',
+  },
+  prolog: {
+    color: '#d4d0ab',
+  },
+  doctype: {
+    color: '#d4d0ab',
+  },
+  cdata: {
+    color: '#d4d0ab',
+  },
+  punctuation: {
+    color: '#fefefe',
+  },
+  property: {
+    color: '#ffa07a',
+  },
+  tag: {
+    color: '#ffa07a',
+  },
+  constant: {
+    color: '#ffa07a',
+  },
+  symbol: {
+    color: '#ffa07a',
+  },
+  deleted: {
+    color: '#ffa07a',
+  },
+  boolean: {
+    color: '#00e0e0',
+  },
+  number: {
+    color: '#00e0e0',
+  },
+  selector: {
+    color: '#abe338',
+  },
+  'attr-name': {
+    color: '#abe338',
+  },
+  string: {
+    color: '#abe338',
+  },
+  char: {
+    color: '#abe338',
+  },
+  builtin: {
+    color: '#abe338',
+  },
+  inserted: {
+    color: '#abe338',
+  },
+  operator: {
+    color: '#00e0e0',
+  },
+  entity: {
+    color: '#00e0e0',
+    cursor: 'help',
+  },
+  url: {
+    color: '#00e0e0',
+  },
+  '.language-css .token.string': {
+    color: '#00e0e0',
+  },
+  '.style .token.string': {
+    color: '#00e0e0',
+  },
+  variable: {
+    color: '#00e0e0',
+  },
+  atrule: {
+    color: '#ffd700',
+  },
+  'attr-value': {
+    color: '#ffd700',
+  },
+  function: {
+    color: '#ffd700',
+  },
+  keyword: {
+    color: '#00e0e0',
+  },
+  regex: {
+    color: '#ffd700',
+  },
+  important: {
+    color: '#ffd700',
+    fontWeight: 'bold',
+  },
+  bold: {
+    fontWeight: 'bold',
+  },
+  italic: {
+    fontStyle: 'italic',
+  },
+};

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -30,12 +30,11 @@ const MarkdownLayout = styled(Markdown)`
   }
 
   & > p > code {
-    color: rgb(248, 248, 242);
-    background: rgb(43, 43, 43);
-    font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
-    text-align: left;
-    white-space: pre;
-    font-size: 20px;
+    color: #f8f8f2;
+    background: #2b2b2b;
+    padding: 0.1em;
+    border-radius: 0.3em;
+    white-space: normal;
   }
 `;
 

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -28,14 +28,6 @@ const MarkdownLayout = styled(Markdown)`
     margin-top: 0;
     padding-top: 0;
   }
-
-  & > p > code {
-    color: #f8f8f2;
-    background: #2b2b2b;
-    padding: 0.1em;
-    border-radius: 0.3em;
-    white-space: normal;
-  }
 `;
 
 const columns = {

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -28,11 +28,11 @@ const MarkdownLayout = styled(Markdown)`
     margin-top: 0;
     padding-top: 0;
   }
-  
+
   & > p > code {
     color: rgb(248, 248, 242);
     background: rgb(43, 43, 43);
-    font-family: Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace;
+    font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
     text-align: left;
     white-space: pre;
     font-size: 20px;

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -28,6 +28,15 @@ const MarkdownLayout = styled(Markdown)`
     margin-top: 0;
     padding-top: 0;
   }
+  
+  & > p > code {
+    color: rgb(248, 248, 242);
+    background: rgb(43, 43, 43);
+    font-family: Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace;
+    text-align: left;
+    white-space: pre;
+    font-size: 20px;
+  }
 `;
 
 const columns = {


### PR DESCRIPTION
## Issue
Issue: Inline code snippet looks bad https://github.com/hpe-dev-incubator/hpe-dev-portal/issues/478
e.g: https://developer.hpe.com/blog/using-python-with-apache-spark/
<img width="1008" alt="Screen Shot 2021-05-16 at 8 10 21 PM" src="https://user-images.githubusercontent.com/11492092/118513523-a44b5380-b6e8-11eb-9cc9-312618694651.png">

## Attempted Changes
I looked into [gatsby-remark-prismjs](https://www.gatsbyjs.com/plugins/gatsby-remark-prismjs)(already installed) which allows you to specify a language in an inline code block. An example can be seen [here](https://www.gatsbyjs.com/plugins/gatsby-remark-prismjs/#inline-code-blocks). I tried setting this up by setting a seperator for  `inlineCodeMarker`, but the prismjs plugin doesn't seem to be able to read it. I've tried the following:
- Updating the npm packges `gatsby-transformer-remark gatsby-remark-prismjs prismjs`
- Ran `yarn build` and `yarn serve`
- Remove `node_modules` then reinstall packages

I'm not sure if some other package/plugin that is stopping it from reading the `gatsby-remak-primjs` configuration.

## Proposed Changes
From looking at the blogs from HPE Dev portal v1 the inline code wasn't specified by language, so I manually updated inline code CSS by targeting the `<code>`  tag. I took the CSS from the already existing three back ticks(```) code block within the blog.
<img width="1026" alt="Screen Shot 2021-05-16 at 9 16 04 PM" src="https://user-images.githubusercontent.com/11492092/118513543-aca38e80-b6e8-11eb-9da7-1b8e68cd9bc4.png">

## Test
https://deploy-preview-486--hpe-dev-portal.netlify.app/blog/using-python-with-apache-spark/