### PR TITLE
Change Discover event card URL

### DIFF
--- a/content/event/hpe-discover.md
+++ b/content/event/hpe-discover.md
@@ -4,7 +4,7 @@ dateStart: 2021-06-22T06:00:01.558Z
 dateEnd: 2021-06-24T15:00:01.583Z
 category: Virtual Event
 image: /img/discover-event-logo.png
-link: https://content.attend.hpe.com/go/virtualplatform.catalogue/?l=1045&sf=1166&locale=en_US
+link: https://content.attend.hpe.com/go/virtualplatform.catalogue_session/?l=1045&sf=2879&locale=en_US
 width: large
 tags:
   - Discover


### PR DESCRIPTION
### Issue
The old url was taking user to the wrong website. I have changed it to the correct url: https://content.attend.hpe.com/go/virtualplatform.catalogue_session/?l=1045&sf=2879&locale=en_US