### PR TITLE
#577 Categorize the blogs page by platforms, open source and others

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -10,3 +10,4 @@ out/
 public/
 yarn.lock
 package-lock.json
+plugins/

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -175,7 +175,52 @@ module.exports = {
         {
           allMarkdownRemark(filter: {fields: {sourceInstanceName: {eq: "blog"}
         }, frontmatter: {featuredBlog: {ne: true}}},
-         sort: {fields: [frontmatter___date], order: DESC}) {
+          sort: {fields: [frontmatter___date], order: DESC}) {
+            nodes {
+              id
+              fields {
+                slug
+                sourceInstanceName
+              }
+              frontmatter {
+                title
+                date
+                description
+                author
+                tags
+                authorimage
+              }
+              excerpt
+            }
+          }
+        }
+        `,
+        normalizer: ({ data }) =>
+          data.allMarkdownRemark.nodes.map((node) => ({
+            id: node.id,
+            title: node.frontmatter.title,
+            date: node.frontmatter.date,
+            description: node.excerpt,
+            author: node.frontmatter.author,
+            tags: node.frontmatter.tags,
+            authorimage: node.frontmatter.authorimage,
+            fields: {
+              slug: node.fields.slug,
+              sourceInstanceName: node.fields.sourceInstanceName,
+            },
+          })),
+      },
+    },
+    {
+      resolve: 'gatsby-plugin-paginated-collection',
+      options: {
+        name: 'opensource-blog-posts',
+        pageSize: 12,
+        query: `
+        {
+          allMarkdownRemark(filter: {fields: {sourceInstanceName: {eq: "blog"}
+        }, frontmatter: {tags: {eq: "opensource"}}},
+          sort: {fields: [frontmatter___date], order: DESC}) {
             nodes {
               id
               fields {
@@ -239,9 +284,9 @@ module.exports = {
               node.fields.sourceInstanceName === 'homepanels'
                 ? '/'
                 : `${node.fields.sourceInstanceName}${node.fields.slug.replace(
-                    /\/aside[/]?$/,
-                    '/home',
-                  )}`,
+                  /\/aside[/]?$/,
+                  '/home',
+                )}`,
             sourceInstanceName: (node) => node.fields.sourceInstanceName,
           },
         },
@@ -249,3 +294,7 @@ module.exports = {
     },
   ],
 };
+
+
+
+

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -259,9 +259,79 @@ module.exports = {
           })),
       },
     },
+    {
+      resolve: 'gatsby-plugin-paginated-collection',
+      options: {
+        name: 'others-posts',
+        pageSize: 12,
+        query: `
+        {
+          allMarkdownRemark(filter: {fields: {sourceInstanceName: {eq: "blog"}
+          }, frontmatter: {tags: {nin: [
+          "opensource", 
+          "hpe-ezmeral-container-platform", 
+          "spiffe-and-spire-projects", 
+          "hpe-ezmeral-data-fabric", 
+          "hpe-greenlake", 
+          "chapel", 
+          "grommet", 
+          "hpe-alletra", 
+          "deep-learning-cookbook", 
+          "hpe-3par-and-primera", 
+          "hpe-nimble-storage", 
+          "hpe-oneview", 
+          "hpe-oneview-global-dashboard", 
+          "ilo"]}}}, sort: {fields: [frontmatter___date], order: DESC}) {
+            nodes {
+              id
+              fields {
+                slug
+                sourceInstanceName
+              }
+              frontmatter {
+                title
+                date
+                description
+                author
+                tags
+                authorimage
+              }
+              excerpt
+            }
+          }
+        }
+        `,
+        normalizer: ({ data }) =>
+          data.allMarkdownRemark.nodes.map((node) => ({
+            id: node.id,
+            title: node.frontmatter.title,
+            date: node.frontmatter.date,
+            description: node.excerpt,
+            author: node.frontmatter.author,
+            tags: node.frontmatter.tags,
+            authorimage: node.frontmatter.authorimage,
+            fields: {
+              slug: node.fields.slug,
+              sourceInstanceName: node.fields.sourceInstanceName,
+            },
+          })),
+      },
+    },
     paginatedCollection('opensource-blog-posts', 'opensource'),
     paginatedCollection('ezmeral-blog-posts', 'hpe-ezmeral-container-platform'),
     paginatedCollection('spiffe-blog-posts', 'spiffe-and-spire-projects'),
+    paginatedCollection('data-fabric-posts', 'hpe-ezmeral-data-fabric'),
+    paginatedCollection('greenlake-posts', 'hpe-greenlake'),
+    paginatedCollection('chapel-posts', 'chapel'),
+    paginatedCollection('grommet-posts', 'grommet'),
+    paginatedCollection('alletra-posts', 'hpe-alletra'),
+    paginatedCollection('deep-learning-posts', 'deep-learning-cookbook'),
+    paginatedCollection('3par-posts', 'hpe-3par-and-primera'),
+    paginatedCollection('nimble-posts', 'hpe-nimble-storage'),
+    paginatedCollection('oneview-posts', 'hpe-oneview'),
+    paginatedCollection('oneview-dashboard-posts', 
+      'hpe-oneview-global-dashboard'),
+    paginatedCollection('ilo-posts', 'ilo'),
     {
       resolve: 'gatsby-plugin-lunr',
       options: {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -18,6 +18,54 @@ const stripMarkdown = (markdown) => {
   return text;
 };
 
+const paginatedCollection = (name, tag) => {
+  return {
+    resolve: 'gatsby-plugin-paginated-collection',
+    options: {
+      name,
+      pageSize: 12,
+      query: `
+      {
+        allMarkdownRemark(filter: {fields: {sourceInstanceName: {eq: "blog"}
+      }, frontmatter: {tags: {eq: "${tag}"}}},
+        sort: {fields: [frontmatter___date], order: DESC}) {
+          nodes {
+            id
+            fields {
+              slug
+              sourceInstanceName
+            }
+            frontmatter {
+              title
+              date
+              description
+              author
+              tags
+              authorimage
+            }
+            excerpt
+          }
+        }
+      }
+      `,
+      normalizer: ({ data }) =>
+        data.allMarkdownRemark.nodes.map((node) => ({
+          id: node.id,
+          title: node.frontmatter.title,
+          date: node.frontmatter.date,
+          description: node.excerpt,
+          author: node.frontmatter.author,
+          tags: node.frontmatter.tags,
+          authorimage: node.frontmatter.authorimage,
+          fields: {
+            slug: node.fields.slug,
+            sourceInstanceName: node.fields.sourceInstanceName,
+          },
+        })),
+    },
+  };
+};
+
 module.exports = {
   siteMetadata: {
     title: 'HPE Developer Portal',
@@ -211,96 +259,9 @@ module.exports = {
           })),
       },
     },
-    {
-      resolve: 'gatsby-plugin-paginated-collection',
-      options: {
-        name: 'opensource-blog-posts',
-        pageSize: 12,
-        query: `
-        {
-          allMarkdownRemark(filter: {fields: {sourceInstanceName: {eq: "blog"}
-        }, frontmatter: {tags: {eq: "opensource"}}},
-          sort: {fields: [frontmatter___date], order: DESC}) {
-            nodes {
-              id
-              fields {
-                slug
-                sourceInstanceName
-              }
-              frontmatter {
-                title
-                date
-                description
-                author
-                tags
-                authorimage
-              }
-              excerpt
-            }
-          }
-        }
-        `,
-        normalizer: ({ data }) =>
-          data.allMarkdownRemark.nodes.map((node) => ({
-            id: node.id,
-            title: node.frontmatter.title,
-            date: node.frontmatter.date,
-            description: node.excerpt,
-            author: node.frontmatter.author,
-            tags: node.frontmatter.tags,
-            authorimage: node.frontmatter.authorimage,
-            fields: {
-              slug: node.fields.slug,
-              sourceInstanceName: node.fields.sourceInstanceName,
-            },
-          })),
-      },
-    },
-    {
-      resolve: 'gatsby-plugin-paginated-collection',
-      options: {
-        name: 'ezmeral-blog-posts',
-        pageSize: 12,
-        query: `
-        {
-          allMarkdownRemark(filter: {fields: {sourceInstanceName: {eq: "blog"}
-        }, frontmatter: {tags: {eq: "hpe-ezmeral-container-platform"}}},
-          sort: {fields: [frontmatter___date], order: DESC}) {
-            nodes {
-              id
-              fields {
-                slug
-                sourceInstanceName
-              }
-              frontmatter {
-                title
-                date
-                description
-                author
-                tags
-                authorimage
-              }
-              excerpt
-            }
-          }
-        }
-        `,
-        normalizer: ({ data }) =>
-          data.allMarkdownRemark.nodes.map((node) => ({
-            id: node.id,
-            title: node.frontmatter.title,
-            date: node.frontmatter.date,
-            description: node.excerpt,
-            author: node.frontmatter.author,
-            tags: node.frontmatter.tags,
-            authorimage: node.frontmatter.authorimage,
-            fields: {
-              slug: node.fields.slug,
-              sourceInstanceName: node.fields.sourceInstanceName,
-            },
-          })),
-      },
-    },
+    paginatedCollection('opensource-blog-posts', 'opensource'),
+    paginatedCollection('ezmeral-blog-posts', 'hpe-ezmeral-container-platform'),
+    paginatedCollection('spiffe-blog-posts', 'spiffe-and-spire-projects'),
     {
       resolve: 'gatsby-plugin-lunr',
       options: {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -257,6 +257,51 @@ module.exports = {
       },
     },
     {
+      resolve: 'gatsby-plugin-paginated-collection',
+      options: {
+        name: 'ezmeral-blog-posts',
+        pageSize: 12,
+        query: `
+        {
+          allMarkdownRemark(filter: {fields: {sourceInstanceName: {eq: "blog"}
+        }, frontmatter: {tags: {eq: "hpe-ezmeral-container-platform"}}},
+          sort: {fields: [frontmatter___date], order: DESC}) {
+            nodes {
+              id
+              fields {
+                slug
+                sourceInstanceName
+              }
+              frontmatter {
+                title
+                date
+                description
+                author
+                tags
+                authorimage
+              }
+              excerpt
+            }
+          }
+        }
+        `,
+        normalizer: ({ data }) =>
+          data.allMarkdownRemark.nodes.map((node) => ({
+            id: node.id,
+            title: node.frontmatter.title,
+            date: node.frontmatter.date,
+            description: node.excerpt,
+            author: node.frontmatter.author,
+            tags: node.frontmatter.tags,
+            authorimage: node.frontmatter.authorimage,
+            fields: {
+              slug: node.fields.slug,
+              sourceInstanceName: node.fields.sourceInstanceName,
+            },
+          })),
+      },
+    },
+    {
       resolve: 'gatsby-plugin-lunr',
       options: {
         languages: [{ name: 'en', plugins: [lunrHighlightPlugin] }],

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -54,11 +54,47 @@ exports.createPages = async ({ graphql, actions }) => {
     await graphql(paginatedCollectionQuery('ezmeral-blog-posts'));
   const spiffeQueryResult = 
     await graphql(paginatedCollectionQuery('spiffe-blog-posts'));
-  
+  const dataFabricQueryResult = 
+    await graphql(paginatedCollectionQuery('data-fabric-posts'));
+  const greenLakeQueryResult = 
+    await graphql(paginatedCollectionQuery('greenlake-posts'));
+  const chapelQueryResult = 
+    await graphql(paginatedCollectionQuery('chapel-posts'));
+  const grommetQueryResult = 
+    await graphql(paginatedCollectionQuery('grommet-posts'));
+  const alletraQueryResult = 
+    await graphql(paginatedCollectionQuery('alletra-posts'));
+  const deepLearningQueryResult = 
+    await graphql(paginatedCollectionQuery('deep-learning-posts'));
+  const threeParQueryResult = 
+    await graphql(paginatedCollectionQuery('3par-posts'));
+  const nimbleQueryResult = 
+    await graphql(paginatedCollectionQuery('nimble-posts'));
+  const oneviewQueryResult = 
+    await graphql(paginatedCollectionQuery('oneview-posts'));
+  const oneviewDashboardQueryResult = 
+    await graphql(paginatedCollectionQuery('oneview-dashboard-posts'));
+  const iloQueryResult = 
+    await graphql(paginatedCollectionQuery('ilo-posts'));
+  const othersQueryResult = 
+    await graphql(paginatedCollectionQuery('ilo-posts'));
+
   setPagination(allQueryResult);
   setPagination(openSourceQueryResult);
   setPagination(ezmeralQueryResult);
   setPagination(spiffeQueryResult);
+  setPagination(dataFabricQueryResult);
+  setPagination(greenLakeQueryResult);
+  setPagination(chapelQueryResult);
+  setPagination(grommetQueryResult);
+  setPagination(alletraQueryResult);
+  setPagination(deepLearningQueryResult);
+  setPagination(threeParQueryResult);
+  setPagination(nimbleQueryResult);
+  setPagination(oneviewQueryResult);
+  setPagination(oneviewDashboardQueryResult);
+  setPagination(iloQueryResult);
+  setPagination(othersQueryResult);
 
   return graphql(
     `

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -63,8 +63,25 @@ exports.createPages = async ({ graphql, actions }) => {
   }
 `);
 
+  const ezmeralQueryResult = await graphql(`
+{
+  paginatedCollection(name: { eq: "ezmeral-blog-posts" }) {
+    id
+    pages {
+      id
+      nodes
+      hasNextPage
+      nextPage {
+        id
+      }
+    }
+  }
+}
+`);
+
   setPagination(allQueryResult);
   setPagination(openSourceQueryResult);
+  setPagination(ezmeralQueryResult);
 
   return graphql(
     `

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -21,35 +21,9 @@ const setPagination = (queryResult) => {
   );
 };
 
-exports.createPages = async ({ graphql, actions }) => {
-  const { createPage } = actions;
-
-  const blogPost = path.resolve('./src/templates/blog-post.js');
-  const platform = path.resolve('./src/templates/platform.js');
-  const event = path.resolve('./src/templates/event.js');
-  const newsletter = path.resolve('./src/templates/newsletter.js');
-  const tagTemplate = path.resolve('./src/templates/tags.js');
-  const campaignTemplate = path.resolve('./src/templates/campaign.js');
-
-  const allQueryResult = await graphql(`
-    {
-      paginatedCollection(name: { eq: "blog-posts" }) {
-        id
-        pages {
-          id
-          nodes
-          hasNextPage
-          nextPage {
-            id
-          }
-        }
-      }
-    }
-  `);
-
-  const openSourceQueryResult = await graphql(`
-  {
-    paginatedCollection(name: { eq: "opensource-blog-posts" }) {
+const paginatedCollectionQuery = (paginatedName) => {
+  return `{
+    paginatedCollection(name: { eq: "${paginatedName}" }) {
       id
       pages {
         id
@@ -60,28 +34,31 @@ exports.createPages = async ({ graphql, actions }) => {
         }
       }
     }
-  }
-`);
+  }`;
+};
 
-  const ezmeralQueryResult = await graphql(`
-{
-  paginatedCollection(name: { eq: "ezmeral-blog-posts" }) {
-    id
-    pages {
-      id
-      nodes
-      hasNextPage
-      nextPage {
-        id
-      }
-    }
-  }
-}
-`);
+exports.createPages = async ({ graphql, actions }) => {
+  const { createPage } = actions;
 
+  const blogPost = path.resolve('./src/templates/blog-post.js');
+  const platform = path.resolve('./src/templates/platform.js');
+  const event = path.resolve('./src/templates/event.js');
+  const newsletter = path.resolve('./src/templates/newsletter.js');
+  const tagTemplate = path.resolve('./src/templates/tags.js');
+  const campaignTemplate = path.resolve('./src/templates/campaign.js');
+
+  const allQueryResult = await graphql(paginatedCollectionQuery('blog-posts'));
+  const openSourceQueryResult = 
+    await graphql(paginatedCollectionQuery('opensource-blog-posts'));
+  const ezmeralQueryResult = 
+    await graphql(paginatedCollectionQuery('ezmeral-blog-posts'));
+  const spiffeQueryResult = 
+    await graphql(paginatedCollectionQuery('spiffe-blog-posts'));
+  
   setPagination(allQueryResult);
   setPagination(openSourceQueryResult);
   setPagination(ezmeralQueryResult);
+  setPagination(spiffeQueryResult);
 
   return graphql(
     `

--- a/src/components/BlogCard/index.js
+++ b/src/components/BlogCard/index.js
@@ -12,6 +12,7 @@ import {
   CardHeader,
   Paragraph,
 } from 'grommet';
+import { useLocalStorage } from '../../hooks/use-local-storage';
 
 const dateFormat = Intl.DateTimeFormat('default', {
   year: 'numeric',
@@ -29,51 +30,55 @@ const stripMarkdown = (markdown) => {
   return text;
 };
 
-export const BlogCard = ({ node, ...rest }) => (
-  <GrommetCard
-    pad="large"
-    direction="row"
-    justify="between"
-    {...rest}
-    elevation="medium"
-    wrap
-    onClick={
-      node.fields.slug && node.fields.sourceInstanceName
-        ? (e) => {
-            navigate(`/${node.fields.sourceInstanceName}${node.fields.slug}`);
-            localStorage.setItem(
-              'blogPosition',
-              JSON.stringify(e.nativeEvent.pageY - e.nativeEvent.clientY),
-            );
-          }
-        : undefined
-    }
-  >
-    <Box gap="small">
-      <Box align="start">
-        {(node.authorimage || node.frontmatter.authorimage) && (
-          <Image
-            width="96px"
-            height="96px"
-            src={node.authorimage || node.frontmatter.authorimage}
-            alt="author logo"
-          />
+export const BlogCard = ({ node, ...rest }) => {
+  // eslint-disable-next-line no-unused-vars
+  const [blogPosition, setBlogPosition] = useLocalStorage('blogPosition');
+
+  return (
+    <GrommetCard
+      pad="large"
+      direction="row"
+      justify="between"
+      {...rest}
+      elevation="medium"
+      wrap
+      onClick={
+        node.fields.slug && node.fields.sourceInstanceName
+          ? (e) => {
+              navigate(`/${node.fields.sourceInstanceName}${node.fields.slug}`);
+              setBlogPosition(e.nativeEvent.pageY - e.nativeEvent.clientY);
+            }
+          : undefined
+      }
+    >
+      <Box gap="small">
+        <Box align="start">
+          {(node.authorimage || node.frontmatter.authorimage) && (
+            <Image
+              width="96px"
+              height="96px"
+              src={node.authorimage || node.frontmatter.authorimage}
+              alt="author logo"
+            />
+          )}
+        </Box>
+        <Box align="start">
+          <Text>{node.author || node.frontmatter.author}</Text>
+        </Box>
+        <Heading level={4} margin="none">
+          {node.title || node.frontmatter.title}
+        </Heading>
+        {(node.date || node.frontmatter.date) && (
+          <Text color="text-weak">
+            {`${dateFormat.format(
+              new Date(node.date || node.frontmatter.date),
+            )}`}
+          </Text>
         )}
       </Box>
-      <Box align="start">
-        <Text>{node.author || node.frontmatter.author}</Text>
-      </Box>
-      <Heading level={4} margin="none">
-        {node.title || node.frontmatter.title}
-      </Heading>
-      {(node.date || node.frontmatter.date) && (
-        <Text color="text-weak">
-          {`${dateFormat.format(new Date(node.date || node.frontmatter.date))}`}
-        </Text>
-      )}
-    </Box>
-  </GrommetCard>
-);
+    </GrommetCard>
+  );
+};
 
 BlogCard.propTypes = {
   node: PropTypes.shape({

--- a/src/components/BlogTabContent/index.js
+++ b/src/components/BlogTabContent/index.js
@@ -5,46 +5,46 @@ import { Box, Button } from 'grommet';
 import { FormDown } from 'grommet-icons';
 import { BlogCard } from '../BlogCard';
 import ResponsiveGrid from '../ResponsiveGrid';
+import { useLocalStorage } from '../../hooks/use-local-storage';
 
-const OpenSourceTab = ({
+const BlogTabContent = ({
   initialPage,
-  location,
   columns,
   activeTab,
-  platform,
 }) => {
   const [latestPage, setLatestPage] = useState(initialPage);
   const [blogPosts, setBlogPosts] = useState(initialPage.nodes);
   const [collectionId, setCollectionId] = useState(initialPage.collection.id);
+  // eslint-disable-next-line no-unused-vars
+  const [activeBlogTab, setActiveBlogTab] = useLocalStorage('activeBlogTab');
+  const [loadMoreBlogData, setLoadMoreBlogData] = 
+    useLocalStorage('loadMoreBlogData');
 
   useEffect(() => {
     setCollectionId(initialPage.collection.id);
 
     // persist active tab for when user goes back to blog page
-    localStorage.setItem('blogTab', JSON.stringify(activeTab));
-
-    // platform tab needs to be opened for when user goes back
-    // to blog page platform tab
-    if (platform) {
-      localStorage.setItem('openDropButton', JSON.stringify(true));
-    } else {
-      localStorage.setItem('openDropButton', JSON.stringify(false));
-    }
+    // localStorage.setItem('blogTab', JSON.stringify(activeTab));
+    setActiveBlogTab(activeTab);
 
     // loads blogs from user clicks 'Load More'
     // for when user goes back to blog page
-    const blogData = JSON.parse(localStorage.getItem('blogData'));
-
     if (
-      blogData &&
-      blogData.latestPage &&
-      blogData.latestBlogPosts &&
-      blogData.collectionId === collectionId
+      loadMoreBlogData &&
+      loadMoreBlogData.latestPage &&
+      loadMoreBlogData.latestBlogPosts &&
+      loadMoreBlogData.collectionId === collectionId
     ) {
-      setLatestPage(blogData.latestPage);
-      setBlogPosts(blogData.latestBlogPosts);
+      setLatestPage(loadMoreBlogData.latestPage);
+      setBlogPosts(loadMoreBlogData.latestBlogPosts);
     }
-  }, [initialPage, location, activeTab, platform, collectionId]);
+  }, [
+      initialPage, 
+      setActiveBlogTab,
+      activeTab,
+      collectionId,
+      loadMoreBlogData,
+    ]);
 
   const loadNextPage = useCallback(async () => {
     if (!latestPage.hasNextPage) return;
@@ -57,15 +57,12 @@ const OpenSourceTab = ({
     setBlogPosts((state) => [...state, ...json.nodes]);
     setLatestPage(json);
 
-    localStorage.setItem(
-      'blogData',
-      JSON.stringify({
-        latestBlogPosts: [...blogPosts, ...json.nodes],
-        latestPage: json,
-        collectionId,
-      }),
-    );
-  }, [latestPage, collectionId, blogPosts]);
+    setLoadMoreBlogData({
+      latestBlogPosts: [...blogPosts, ...json.nodes],
+      latestPage: json,
+      collectionId,
+    });
+  }, [latestPage, collectionId, blogPosts, setLoadMoreBlogData]);
 
   return (
     <>
@@ -90,7 +87,7 @@ const OpenSourceTab = ({
   );
 };
 
-OpenSourceTab.propTypes = {
+BlogTabContent.propTypes = {
   initialPage: PropTypes.shape({
     nodes: PropTypes.arrayOf(
       PropTypes.shape({
@@ -117,9 +114,7 @@ OpenSourceTab.propTypes = {
     large: PropTypes.arrayOf(PropTypes.string),
     xlarge: PropTypes.arrayOf(PropTypes.string),
   }),
-  location: PropTypes.objectOf(PropTypes.string),
   activeTab: PropTypes.number,
-  platform: PropTypes.bool,
 };
 
-export default OpenSourceTab;
+export default BlogTabContent;

--- a/src/components/BlogTabContent/index.js
+++ b/src/components/BlogTabContent/index.js
@@ -7,12 +7,14 @@ import { BlogCard } from '../BlogCard';
 import ResponsiveGrid from '../ResponsiveGrid';
 import { useLocalStorage } from '../../hooks/use-local-storage';
 
-const BlogTabContent = ({ initialPage, columns, activeTab }) => {
+const BlogTabContent = ({ initialPage, columns, activeTab, platform }) => {
   const [latestPage, setLatestPage] = useState(initialPage);
   const [blogPosts, setBlogPosts] = useState(initialPage.nodes);
   const [collectionId, setCollectionId] = useState(initialPage.collection.id);
-  // eslint-disable-next-line no-unused-vars
+  /* eslint-disable no-unused-vars */
   const [activeBlogTab, setActiveBlogTab] = useLocalStorage('activeBlogTab');
+  const [activePlatform, setActivePlatform] = useLocalStorage('activePlatform');
+  /* eslint-disable no-unused-vars */
   const [loadMoreBlogData, setLoadMoreBlogData] = useLocalStorage(
     'loadMoreBlogData',
   );
@@ -23,6 +25,11 @@ const BlogTabContent = ({ initialPage, columns, activeTab }) => {
     // persist active tab for when user goes back to blog page
     // localStorage.setItem('blogTab', JSON.stringify(activeTab));
     setActiveBlogTab(activeTab);
+
+    // persist if platform dropdown is selected and saves active dropdown item
+    if (!platform) {
+      setActivePlatform('');
+    }
 
     // loads blogs from user clicks 'Load More'
     // for when user goes back to blog page
@@ -41,6 +48,8 @@ const BlogTabContent = ({ initialPage, columns, activeTab }) => {
     activeTab,
     collectionId,
     loadMoreBlogData,
+    platform,
+    setActivePlatform,
   ]);
 
   const loadNextPage = useCallback(async () => {
@@ -112,6 +121,7 @@ BlogTabContent.propTypes = {
     xlarge: PropTypes.arrayOf(PropTypes.string),
   }),
   activeTab: PropTypes.number,
+  platform: PropTypes.string,
 };
 
 export default BlogTabContent;

--- a/src/components/BlogTabContent/index.js
+++ b/src/components/BlogTabContent/index.js
@@ -7,18 +7,15 @@ import { BlogCard } from '../BlogCard';
 import ResponsiveGrid from '../ResponsiveGrid';
 import { useLocalStorage } from '../../hooks/use-local-storage';
 
-const BlogTabContent = ({
-  initialPage,
-  columns,
-  activeTab,
-}) => {
+const BlogTabContent = ({ initialPage, columns, activeTab }) => {
   const [latestPage, setLatestPage] = useState(initialPage);
   const [blogPosts, setBlogPosts] = useState(initialPage.nodes);
   const [collectionId, setCollectionId] = useState(initialPage.collection.id);
   // eslint-disable-next-line no-unused-vars
   const [activeBlogTab, setActiveBlogTab] = useLocalStorage('activeBlogTab');
-  const [loadMoreBlogData, setLoadMoreBlogData] = 
-    useLocalStorage('loadMoreBlogData');
+  const [loadMoreBlogData, setLoadMoreBlogData] = useLocalStorage(
+    'loadMoreBlogData',
+  );
 
   useEffect(() => {
     setCollectionId(initialPage.collection.id);
@@ -39,12 +36,12 @@ const BlogTabContent = ({
       setBlogPosts(loadMoreBlogData.latestBlogPosts);
     }
   }, [
-      initialPage, 
-      setActiveBlogTab,
-      activeTab,
-      collectionId,
-      loadMoreBlogData,
-    ]);
+    initialPage,
+    setActiveBlogTab,
+    activeTab,
+    collectionId,
+    loadMoreBlogData,
+  ]);
 
   const loadNextPage = useCallback(async () => {
     if (!latestPage.hasNextPage) return;

--- a/src/components/BlogTabs/index.js
+++ b/src/components/BlogTabs/index.js
@@ -1,12 +1,12 @@
 import React, { useEffect, useState, useContext } from 'react';
 import PropTypes from 'prop-types';
-import { 
-  Tab, 
-  Tabs, 
-  Menu, 
-  Text, 
-  Grommet, 
-  Box, 
+import {
+  Tab,
+  Tabs,
+  Menu,
+  Text,
+  Grommet,
+  Box,
   ResponsiveContext,
 } from 'grommet';
 import { FormDown } from 'grommet-icons';
@@ -142,7 +142,7 @@ function BlogTabs({ data, columns }) {
             >
               <Box
                 width="116px"
-                height={size === 'small' ? '36px': '48px'}
+                height={size === 'small' ? '36px' : '48px'}
                 justify="center"
                 align="center"
                 direction="row"

--- a/src/components/BlogTabs/index.js
+++ b/src/components/BlogTabs/index.js
@@ -1,0 +1,260 @@
+import React, { useEffect, useState, useContext } from 'react';
+import PropTypes from 'prop-types';
+import { 
+  Tab, 
+  Tabs, 
+  Menu, 
+  Text, 
+  Grommet, 
+  Box, 
+  ResponsiveContext,
+} from 'grommet';
+import { FormDown } from 'grommet-icons';
+import { hpe } from 'grommet-theme-hpe';
+import { deepMerge } from 'grommet/utils';
+import { BlogTabContent } from '..';
+import { useLocalStorage } from '../../hooks/use-local-storage';
+
+const customTheme = deepMerge(hpe, {
+  tab: {
+    pad: {
+      vertical: '0',
+      horizontal: '0',
+    },
+  },
+});
+
+function BlogTabs({ data, columns }) {
+  const [index, setIndex] = useState(0);
+  const onActive = (nextIndex) => setIndex(nextIndex);
+  const totalAllBlogsCount = data.allBlogsCount.totalCount;
+  const totalOpenSourceBlogsCount = data.openSourceBlogsCount.totalCount;
+  const [platformContent, setPlatformContent] = useState({
+    key: 0,
+    data: data.allBlogs,
+  });
+  const [activeBlogTab, setActiveBlogTab] = useLocalStorage('activeBlogTab');
+  const [dropDownData, setDropDownData] = useLocalStorage('dropDownData');
+  const [activePlatform, setActivePlatform] = useLocalStorage('activePlatform');
+  const size = useContext(ResponsiveContext);
+
+  useEffect(() => {
+    if (dropDownData && dropDownData.nodes) {
+      setPlatformContent({ data: dropDownData });
+    }
+
+    if (activeBlogTab) {
+      setIndex(activeBlogTab);
+    }
+  }, [dropDownData, activeBlogTab]);
+
+  const platforms = {
+    ezmeralBlogs: {
+      label: 'HPE Ezmeral Container Platform',
+      count: data.ezmeralBlogsCount.totalCount,
+    },
+    spiffeBlogs: {
+      label: 'Spiffee and Spire Projects',
+      count: data.spiffeBlogsCount.totalCount,
+    },
+    dataFabricBlogs: {
+      label: 'HPE Ezmeral Data Fabric',
+      count: data.dataFabricBlogsCount.totalCount,
+    },
+    greenlakeBlogs: {
+      label: 'HPE GreenLake',
+      count: data.greenlakeBlogsCount.totalCount,
+    },
+    chapelBlogs: {
+      label: 'Chapel',
+      count: data.chapelBlogsCount.totalCount,
+    },
+    grommetBlogs: {
+      label: 'Grommet',
+      count: data.grommetBlogsCount.totalCount,
+    },
+    alletraBlogs: {
+      label: 'HPE Alletra',
+      count: data.alletraBlogsCount.totalCount,
+    },
+    deepLearningBlogs: {
+      label: 'HPE Deep Learning Cookbook',
+      count: data.deepLearningBlogsCount.totalCount,
+    },
+    threeParBlogs: {
+      label: 'HPE 3PAR and Primera',
+      count: data.threeParBlogsCount.totalCount,
+    },
+    nimbleBlogs: {
+      label: 'HPE Nimble Storage',
+      count: data.nimbleBlogsCount.totalCount,
+    },
+    oneviewBlogs: {
+      label: 'HPE OneView',
+      count: data.oneviewBlogsCount.totalCount,
+    },
+    oneviewDashboardBlogs: {
+      label: 'HPE OneView Global Dashboard',
+      count: data.oneviewDashboardBlogsCount.totalCount,
+    },
+    iloBlogs: {
+      label: 'iLO RESTful API',
+      count: data.iloBlogsCount.totalCount,
+    },
+  };
+
+  const platformsData = Object.entries(data)
+    .filter((item) => Object.prototype.hasOwnProperty.call(platforms, item[0]))
+    .map((item, i) => {
+      return {
+        label: `${platforms[item[0]].label} (${platforms[item[0]].count})`,
+        active: platforms[item[0]].label === activePlatform,
+        onClick: () => {
+          setActiveBlogTab(index);
+          setDropDownData(item[1]);
+          setPlatformContent({ key: i, data: item[1] });
+          setActivePlatform(platforms[item[0]].label);
+        },
+      };
+    });
+
+  return (
+    <Tabs activeIndex={index} onActive={onActive} justify="start" pad="20px">
+      <Tab title={`All (${totalAllBlogsCount})`}>
+        <BlogTabContent
+          key={index}
+          initialPage={data.allBlogs}
+          columns={columns}
+          activeTab={index}
+        />
+      </Tab>
+      <Grommet theme={customTheme}>
+        <Tab
+          pad="none"
+          title={
+            <Menu
+              /* eslint-disable-next-line no-unneeded-ternary */
+              open={activePlatform ? true : false}
+              dropProps={{
+                align: { top: 'bottom', left: 'left' },
+              }}
+              items={platformsData}
+            >
+              <Box
+                width="116px"
+                height={size === 'small' ? '36px': '48px'}
+                justify="center"
+                align="center"
+                direction="row"
+              >
+                <Text color="black" margin={{ right: 'xsmall' }}>
+                  Platforms
+                </Text>
+                <FormDown />
+              </Box>
+            </Menu>
+          }
+        >
+          <BlogTabContent
+            key={platformContent.key}
+            initialPage={platformContent.data}
+            columns={columns}
+            activeTab={index}
+            platform="true"
+          />
+        </Tab>
+      </Grommet>
+      <Tab title={`Open Source (${totalOpenSourceBlogsCount})`}>
+        <BlogTabContent
+          key={index}
+          initialPage={data.openSourceBlogs}
+          columns={columns}
+          activeTab={index}
+        />
+      </Tab>
+      <Tab title="Others">
+        <BlogTabContent
+          key={index}
+          initialPage={data.othersBlogs}
+          columns={columns}
+          activeTab={index}
+        />
+      </Tab>
+    </Tabs>
+  );
+}
+
+const blogsPropType = PropTypes.shape({
+  nodes: PropTypes.arrayOf(
+    PropTypes.shape({
+      node: PropTypes.shape({
+        title: PropTypes.string.isRequired,
+        author: PropTypes.string.isRequired,
+        date: PropTypes.string,
+        description: PropTypes.string,
+        authorimage: PropTypes.string,
+      }),
+    }).isRequired,
+  ).isRequired,
+  hasNextPage: PropTypes.bool.isRequired,
+  nextPage: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+  }),
+  collection: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+  }),
+}).isRequired;
+
+BlogTabs.propTypes = {
+  data: PropTypes.shape({
+    featuredblogs: PropTypes.shape({
+      edges: PropTypes.arrayOf(
+        PropTypes.shape({
+          node: PropTypes.shape({
+            id: PropTypes.string.isRequired,
+            frontmatter: PropTypes.shape({
+              title: PropTypes.string.isRequired,
+              author: PropTypes.string.isRequired,
+              date: PropTypes.string,
+              description: PropTypes.string,
+              authorimage: PropTypes.string,
+              thumbnailimage: PropTypes.string,
+              category: PropTypes.string,
+            }).isRequired,
+            excerpt: PropTypes.string.isRequired,
+            fields: PropTypes.shape({
+              slug: PropTypes.string.isRequired,
+              sourceInstanceName: PropTypes.string.isRequired,
+            }),
+          }).isRequired,
+        }).isRequired,
+      ).isRequired,
+    }).isRequired,
+    allBlogs: blogsPropType,
+    openSourceBlogs: blogsPropType,
+    othersBlogs: blogsPropType,
+    allBlogsCount: PropTypes.objectOf(PropTypes.number),
+    openSourceBlogsCount: PropTypes.objectOf(PropTypes.number),
+    ezmeralBlogsCount: PropTypes.objectOf(PropTypes.number),
+    spiffeBlogsCount: PropTypes.objectOf(PropTypes.number),
+    dataFabricBlogsCount: PropTypes.objectOf(PropTypes.number),
+    greenlakeBlogsCount: PropTypes.objectOf(PropTypes.number),
+    chapelBlogsCount: PropTypes.objectOf(PropTypes.number),
+    grommetBlogsCount: PropTypes.objectOf(PropTypes.number),
+    alletraBlogsCount: PropTypes.objectOf(PropTypes.number),
+    deepLearningBlogsCount: PropTypes.objectOf(PropTypes.number),
+    threeParBlogsCount: PropTypes.objectOf(PropTypes.number),
+    nimbleBlogsCount: PropTypes.objectOf(PropTypes.number),
+    oneviewBlogsCount: PropTypes.objectOf(PropTypes.number),
+    oneviewDashboardBlogsCount: PropTypes.objectOf(PropTypes.number),
+    iloBlogsCount: PropTypes.objectOf(PropTypes.number),
+  }).isRequired,
+  columns: PropTypes.shape({
+    small: PropTypes.string,
+    medium: PropTypes.arrayOf(PropTypes.string),
+    large: PropTypes.arrayOf(PropTypes.string),
+    xlarge: PropTypes.arrayOf(PropTypes.string),
+  }),
+};
+
+export default BlogTabs;

--- a/src/components/BlogTabs/index.js
+++ b/src/components/BlogTabs/index.js
@@ -29,6 +29,7 @@ function BlogTabs({ data, columns }) {
   const onActive = (nextIndex) => setIndex(nextIndex);
   const totalAllBlogsCount = data.allBlogsCount.totalCount;
   const totalOpenSourceBlogsCount = data.openSourceBlogsCount.totalCount;
+  const totalOthersBlogsCount = data.othersBlogsCount.totalCount;
   const [platformContent, setPlatformContent] = useState({
     key: 0,
     data: data.allBlogs,
@@ -118,6 +119,16 @@ function BlogTabs({ data, columns }) {
       };
     });
 
+  /* eslint-disable no-param-reassign */
+  const totalAllPlatformsBlogsCount = Object.entries(platforms).reduce(
+    (accum, item) => {
+      accum += item[1].count;
+      return accum;
+    },
+    0,
+  );
+  /* eslint-disable no-param-reassign */
+
   return (
     <Tabs activeIndex={index} onActive={onActive} justify="start" pad="20px">
       <Tab title={`All (${totalAllBlogsCount})`}>
@@ -141,14 +152,14 @@ function BlogTabs({ data, columns }) {
               items={platformsData}
             >
               <Box
-                width="116px"
+                width="160px"
                 height={size === 'small' ? '36px' : '48px'}
                 justify="center"
                 align="center"
                 direction="row"
               >
                 <Text color="black" margin={{ right: 'xsmall' }}>
-                  Platforms
+                  Platforms ({totalAllPlatformsBlogsCount})
                 </Text>
                 <FormDown />
               </Box>
@@ -172,7 +183,7 @@ function BlogTabs({ data, columns }) {
           activeTab={index}
         />
       </Tab>
-      <Tab title="Others">
+      <Tab title={`Others (${totalOthersBlogsCount})`}>
         <BlogTabContent
           key={index}
           initialPage={data.othersBlogs}
@@ -248,6 +259,7 @@ BlogTabs.propTypes = {
     oneviewBlogsCount: PropTypes.objectOf(PropTypes.number),
     oneviewDashboardBlogsCount: PropTypes.objectOf(PropTypes.number),
     iloBlogsCount: PropTypes.objectOf(PropTypes.number),
+    othersBlogsCount: PropTypes.objectOf(PropTypes.number),
   }).isRequired,
   columns: PropTypes.shape({
     small: PropTypes.string,

--- a/src/components/OpenSourceTab/index.js
+++ b/src/components/OpenSourceTab/index.js
@@ -43,9 +43,9 @@ const OpenSourceTab = ({
 
   //   if (scrollPosition) {
   //     setTimeout(() => {
-  //       window.scrollTo({ 
-  // top: scrollPosition, 
-  // left: 0, 
+  //       window.scrollTo({
+  // top: scrollPosition,
+  // left: 0,
   // behavior: 'smooth' });
   //     }, 100);
   //   }
@@ -78,17 +78,14 @@ const OpenSourceTab = ({
 
   return (
     <>
-      <ResponsiveGrid rows={{}} columns={columns} >
-        {
-          blogPosts.map(
-            (blogPost) =>
-              blogPost.url !== '/' && (
-                <BlogCard key={blogPost.id} node={blogPost} />
-              ),
-          )
-        }
-
-      </ResponsiveGrid >
+      <ResponsiveGrid rows={{}} columns={columns}>
+        {blogPosts.map(
+          (blogPost) =>
+            blogPost.url !== '/' && (
+              <BlogCard key={blogPost.id} node={blogPost} />
+            ),
+        )}
+      </ResponsiveGrid>
       <Box align="center" pad="medium">
         <Button
           icon={<FormDown />}

--- a/src/components/OpenSourceTab/index.js
+++ b/src/components/OpenSourceTab/index.js
@@ -1,0 +1,135 @@
+import React, { useState, useCallback, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { withPrefix } from 'gatsby';
+import { Box, Button } from 'grommet';
+import { FormDown } from 'grommet-icons';
+import { BlogCard } from '../BlogCard';
+import ResponsiveGrid from '../ResponsiveGrid';
+
+const OpenSourceTab = ({
+  initialPage,
+  // location,
+  columns,
+}) => {
+  console.log('initialPage: ', initialPage);
+  const [latestPage, setLatestPage] = useState(initialPage);
+  const [blogPosts, setBlogPosts] = useState(initialPage.nodes);
+  const [collectionId, setCollectionId] = useState(initialPage.collection.id);
+  useEffect(() => {
+    setCollectionId(initialPage.collection.id);
+
+    //   const blogLocalStorage = JSON.parse(localStorage.getItem('blogData'));
+
+    //   if (
+    //     blogLocalStorage &&
+    //     blogLocalStorage.latestPage &&
+    //     blogLocalStorage.latestBlogPosts
+    //   ) {
+    //     setLatestPage(blogLocalStorage.latestPage);
+    //     setBlogPosts(blogLocalStorage.latestBlogPosts);
+    //   }
+
+    //   if (location.state && location.state.isBlogHeaderClicked) {
+    //     navigate('/blog', { replace: true });
+    //     setLatestPage(initialPage);
+    //     setBlogPosts(initialPage.nodes);
+    //     localStorage.removeItem('blogPosition');
+    //     localStorage.removeItem('blogData');
+    //   }
+  }, [initialPage]);
+
+  // useEffect(() => {
+  //   const scrollPosition = JSON.parse(localStorage.getItem('blogPosition'));
+
+  //   if (scrollPosition) {
+  //     setTimeout(() => {
+  //       window.scrollTo({ 
+  // top: scrollPosition, 
+  // left: 0, 
+  // behavior: 'smooth' });
+  //     }, 100);
+  //   }
+  // }, []);
+
+  const loadNextPage = useCallback(async () => {
+    if (!latestPage.hasNextPage) return;
+    const nextPageId = latestPage.nextPage.id;
+    console.log('collectionId: ', collectionId);
+    console.log('nextPageId: ', nextPageId);
+    const path = withPrefix(
+      `/paginated-data/${collectionId}/${nextPageId}.json`,
+    );
+    console.log('path: ', path);
+    const res = await fetch(path);
+    console.log('res: ', res);
+    const json = await res.json();
+    console.log('json: ', json);
+    setBlogPosts((state) => [...state, ...json.nodes]);
+    setLatestPage(json);
+
+    // localStorage.setItem(
+    //   'blogData',
+    //   JSON.stringify({
+    //     latestBlogPosts: [...blogPosts, ...json.nodes],
+    //     latestPage: json,
+    //   }),
+    // );
+  }, [latestPage, collectionId]);
+
+  return (
+    <>
+      <ResponsiveGrid rows={{}} columns={columns} >
+        {
+          blogPosts.map(
+            (blogPost) =>
+              blogPost.url !== '/' && (
+                <BlogCard key={blogPost.id} node={blogPost} />
+              ),
+          )
+        }
+
+      </ResponsiveGrid >
+      <Box align="center" pad="medium">
+        <Button
+          icon={<FormDown />}
+          hoverIndicator
+          reverse
+          onClick={loadNextPage}
+          label="Load More"
+        />
+      </Box>
+    </>
+  );
+};
+
+OpenSourceTab.propTypes = {
+  initialPage: PropTypes.shape({
+    nodes: PropTypes.arrayOf(
+      PropTypes.shape({
+        node: PropTypes.shape({
+          title: PropTypes.string.isRequired,
+          author: PropTypes.string.isRequired,
+          date: PropTypes.string,
+          description: PropTypes.string,
+          authorimage: PropTypes.string,
+        }),
+      }).isRequired,
+    ).isRequired,
+    hasNextPage: PropTypes.bool.isRequired,
+    nextPage: PropTypes.shape({
+      id: PropTypes.string.isRequired,
+    }),
+    collection: PropTypes.shape({
+      id: PropTypes.string.isRequired,
+    }),
+  }).isRequired,
+  columns: PropTypes.shape({
+    small: PropTypes.string,
+    medium: PropTypes.arrayOf(PropTypes.string),
+    large: PropTypes.arrayOf(PropTypes.string),
+    xlarge: PropTypes.arrayOf(PropTypes.string),
+  }),
+  // location: PropTypes.objectOf(PropTypes.string),
+};
+
+export default OpenSourceTab;

--- a/src/components/OpenSourceTab/index.js
+++ b/src/components/OpenSourceTab/index.js
@@ -8,73 +8,64 @@ import ResponsiveGrid from '../ResponsiveGrid';
 
 const OpenSourceTab = ({
   initialPage,
-  // location,
+  location,
   columns,
+  activeTab,
+  platform,
 }) => {
-  console.log('initialPage: ', initialPage);
   const [latestPage, setLatestPage] = useState(initialPage);
   const [blogPosts, setBlogPosts] = useState(initialPage.nodes);
   const [collectionId, setCollectionId] = useState(initialPage.collection.id);
+
   useEffect(() => {
     setCollectionId(initialPage.collection.id);
 
-    //   const blogLocalStorage = JSON.parse(localStorage.getItem('blogData'));
+    // persist active tab for when user goes back to blog page
+    localStorage.setItem('blogTab', JSON.stringify(activeTab));
 
-    //   if (
-    //     blogLocalStorage &&
-    //     blogLocalStorage.latestPage &&
-    //     blogLocalStorage.latestBlogPosts
-    //   ) {
-    //     setLatestPage(blogLocalStorage.latestPage);
-    //     setBlogPosts(blogLocalStorage.latestBlogPosts);
-    //   }
+    // platform tab needs to be opened for when user goes back
+    // to blog page platform tab
+    if (platform) {
+      localStorage.setItem('openDropButton', JSON.stringify(true));
+    } else {
+      localStorage.setItem('openDropButton', JSON.stringify(false));
+    }
 
-    //   if (location.state && location.state.isBlogHeaderClicked) {
-    //     navigate('/blog', { replace: true });
-    //     setLatestPage(initialPage);
-    //     setBlogPosts(initialPage.nodes);
-    //     localStorage.removeItem('blogPosition');
-    //     localStorage.removeItem('blogData');
-    //   }
-  }, [initialPage]);
+    // loads blogs from user clicks 'Load More'
+    // for when user goes back to blog page
+    const blogData = JSON.parse(localStorage.getItem('blogData'));
 
-  // useEffect(() => {
-  //   const scrollPosition = JSON.parse(localStorage.getItem('blogPosition'));
-
-  //   if (scrollPosition) {
-  //     setTimeout(() => {
-  //       window.scrollTo({
-  // top: scrollPosition,
-  // left: 0,
-  // behavior: 'smooth' });
-  //     }, 100);
-  //   }
-  // }, []);
+    if (
+      blogData &&
+      blogData.latestPage &&
+      blogData.latestBlogPosts &&
+      blogData.collectionId === collectionId
+    ) {
+      setLatestPage(blogData.latestPage);
+      setBlogPosts(blogData.latestBlogPosts);
+    }
+  }, [initialPage, location, activeTab, platform, collectionId]);
 
   const loadNextPage = useCallback(async () => {
     if (!latestPage.hasNextPage) return;
     const nextPageId = latestPage.nextPage.id;
-    console.log('collectionId: ', collectionId);
-    console.log('nextPageId: ', nextPageId);
     const path = withPrefix(
       `/paginated-data/${collectionId}/${nextPageId}.json`,
     );
-    console.log('path: ', path);
     const res = await fetch(path);
-    console.log('res: ', res);
     const json = await res.json();
-    console.log('json: ', json);
     setBlogPosts((state) => [...state, ...json.nodes]);
     setLatestPage(json);
 
-    // localStorage.setItem(
-    //   'blogData',
-    //   JSON.stringify({
-    //     latestBlogPosts: [...blogPosts, ...json.nodes],
-    //     latestPage: json,
-    //   }),
-    // );
-  }, [latestPage, collectionId]);
+    localStorage.setItem(
+      'blogData',
+      JSON.stringify({
+        latestBlogPosts: [...blogPosts, ...json.nodes],
+        latestPage: json,
+        collectionId,
+      }),
+    );
+  }, [latestPage, collectionId, blogPosts]);
 
   return (
     <>
@@ -126,7 +117,9 @@ OpenSourceTab.propTypes = {
     large: PropTypes.arrayOf(PropTypes.string),
     xlarge: PropTypes.arrayOf(PropTypes.string),
   }),
-  // location: PropTypes.objectOf(PropTypes.string),
+  location: PropTypes.objectOf(PropTypes.string),
+  activeTab: PropTypes.number,
+  platform: PropTypes.bool,
 };
 
 export default OpenSourceTab;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -14,7 +14,7 @@ import ResponsiveGrid from './ResponsiveGrid';
 import PlatformCard from './PlatformCard';
 import OpenSourceCard from './OpenSourceCard';
 import CommunityCard from './CommunityCard';
-import OpenSourceTab from './OpenSourceTab';
+import BlogTabContent from './BlogTabContent';
 
 export * from './Card';
 export * from './Link';
@@ -38,5 +38,5 @@ export {
   PlatformCard,
   OpenSourceCard,
   CommunityCard,
-  OpenSourceTab,
+  BlogTabContent,
 };

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -14,6 +14,7 @@ import ResponsiveGrid from './ResponsiveGrid';
 import PlatformCard from './PlatformCard';
 import OpenSourceCard from './OpenSourceCard';
 import CommunityCard from './CommunityCard';
+import OpenSourceTab from './OpenSourceTab';
 
 export * from './Card';
 export * from './Link';
@@ -37,4 +38,5 @@ export {
   PlatformCard,
   OpenSourceCard,
   CommunityCard,
+  OpenSourceTab,
 };

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -14,6 +14,7 @@ import ResponsiveGrid from './ResponsiveGrid';
 import PlatformCard from './PlatformCard';
 import OpenSourceCard from './OpenSourceCard';
 import CommunityCard from './CommunityCard';
+import BlogTabs from './BlogTabs';
 import BlogTabContent from './BlogTabContent';
 
 export * from './Card';
@@ -38,5 +39,6 @@ export {
   PlatformCard,
   OpenSourceCard,
   CommunityCard,
+  BlogTabs,
   BlogTabContent,
 };

--- a/src/hooks/use-local-storage/index.js
+++ b/src/hooks/use-local-storage/index.js
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+
+export function useLocalStorage(key, initialValue) {
+  // State to store our value
+  // Pass initial state function to useState so logic is only executed once
+  const [storedValue, setStoredValue] = useState(() => {
+    try {
+      // Get from local storage by key
+      const item = window.localStorage.getItem(key);
+      // Parse stored json or if none return initialValue
+      return item ? JSON.parse(item) : initialValue;
+    } catch (error) {
+      // If error also return initialValue
+      console.log(error);
+      return initialValue;
+    }
+  });
+  // Return a wrapped version of useState's setter function that ...
+  // ... persists the new value to localStorage.
+  const setValue = (value) => {
+    try {
+      // Allow value to be a function so we have same API as useState
+      const valueToStore =
+        value instanceof Function ? value(storedValue) : value;
+      // Save state
+      setStoredValue(valueToStore);
+      // Save to local storage
+      window.localStorage.setItem(key, JSON.stringify(valueToStore));
+    } catch (error) {
+      // A more advanced implementation would handle the error case
+      console.log(error);
+    }
+  };
+  return [storedValue, setValue];
+}

--- a/src/pages/blog/index.js
+++ b/src/pages/blog/index.js
@@ -1,10 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { graphql, navigate } from 'gatsby';
-import { Paragraph, Tab, Tabs, Menu, Text, Grommet, Box } from 'grommet';
-import { FormDown } from 'grommet-icons';
-import { hpe } from 'grommet-theme-hpe';
-import { deepMerge } from 'grommet/utils';
+import { Paragraph } from 'grommet';
 import {
   BlogCard,
   Layout,
@@ -13,19 +10,10 @@ import {
   FeaturedBlogCard,
   SectionHeader,
   ResponsiveGrid,
-  BlogTabContent,
+  BlogTabs,
 } from '../../components';
 import { useSiteMetadata } from '../../hooks/use-site-metadata';
 import { useLocalStorage } from '../../hooks/use-local-storage';
-
-const customTheme = deepMerge(hpe, {
-  tab: {
-    pad: {
-      vertical: '0',
-      horizontal: '0',
-    },
-  },
-});
 
 const columns = {
   small: 'auto',
@@ -38,99 +26,12 @@ function Blog({ data, location }) {
   const featuredposts = data.featuredblogs.edges;
   const siteMetadata = useSiteMetadata();
   const siteTitle = siteMetadata.title;
+  /* eslint-disable no-unused-vars */
   const [index, setIndex] = useState(0);
-  const onActive = (nextIndex) => setIndex(nextIndex);
-  const totalAllBlogsCount = data.allBlogsCount.totalCount;
-  const totalOpenSourceBlogsCount = data.openSourceBlogsCount.totalCount;
-  const [platformContent, setPlatformContent] = useState({
-    key: 0,
-    data: data.allBlogs,
-  });
-  /* eslint-disable-next-line no-unused-vars */
   const [blogPosition, setBlogPosition] = useLocalStorage('blogPosition');
-  const [activeBlogTab, setActiveBlogTab] = useLocalStorage('activeBlogTab');
-  const [dropDownData, setDropDownData] = useLocalStorage('dropDownData');
-  const [activePlatform, setActivePlatform] = useLocalStorage('activePlatform');
-
-  const platforms = {
-    ezmeralBlogs: {
-      label: 'HPE Ezmeral Container Platform',
-      count: data.ezmeralBlogsCount.totalCount,
-    },
-    spiffeBlogs: {
-      label: 'Spiffee and Spire Projects',
-      count: data.spiffeBlogsCount.totalCount,
-    },
-    dataFabricBlogs: {
-      label: 'HPE Ezmeral Data Fabric',
-      count: data.dataFabricBlogsCount.totalCount,
-    },
-    greenlakeBlogs: {
-      label: 'HPE GreenLake',
-      count: data.greenlakeBlogsCount.totalCount,
-    },
-    chapelBlogs: {
-      label: 'Chapel',
-      count: data.chapelBlogsCount.totalCount,
-    },
-    grommetBlogs: {
-      label: 'Grommet',
-      count: data.grommetBlogsCount.totalCount,
-    },
-    alletraBlogs: {
-      label: 'HPE Alletra',
-      count: data.alletraBlogsCount.totalCount,
-    },
-    deepLearningBlogs: {
-      label: 'HPE Deep Learning Cookbook',
-      count: data.deepLearningBlogsCount.totalCount,
-    },
-    threeParBlogs: {
-      label: 'HPE 3PAR and Primera',
-      count: data.threeParBlogsCount.totalCount,
-    },
-    nimbleBlogs: {
-      label: 'HPE Nimble Storage',
-      count: data.nimbleBlogsCount.totalCount,
-    },
-    oneviewBlogs: {
-      label: 'HPE OneView',
-      count: data.oneviewBlogsCount.totalCount,
-    },
-    oneviewDashboardBlogs: {
-      label: 'HPE OneView Global Dashboard',
-      count: data.oneviewDashboardBlogsCount.totalCount,
-    },
-    iloBlogs: {
-      label: 'iLO RESTful API',
-      count: data.iloBlogsCount.totalCount,
-    },
-  };
-
-  const platformsData = Object.entries(data)
-    .filter((item) => Object.prototype.hasOwnProperty.call(platforms, item[0]))
-    .map((item, i) => {
-      return {
-        label: `${platforms[item[0]].label} (${platforms[item[0]].count})`,
-        active: platforms[item[0]].label === activePlatform,
-        onClick: () => {
-          setActiveBlogTab(index);
-          setDropDownData(item[1]);
-          setPlatformContent({ key: i, data: item[1] });
-          setActivePlatform(platforms[item[0]].label);
-        },
-      };
-    });
+  /* eslint-disable no-unused-vars */
 
   useEffect(() => {
-    if (dropDownData && dropDownData.nodes) {
-      setPlatformContent({ data: dropDownData });
-    }
-
-    if (activeBlogTab) {
-      setIndex(activeBlogTab);
-    }
-
     if (location.state && location.state.isBlogHeaderClicked) {
       navigate('/blog', { replace: true });
       setIndex(0);
@@ -138,7 +39,7 @@ function Blog({ data, location }) {
       localStorage.removeItem('blogData');
       localStorage.removeItem('activeBlogTab');
     }
-  }, [dropDownData, activeBlogTab, location]);
+  }, [location]);
 
   useEffect(() => {
     const scrollPosition = blogPosition;
@@ -184,91 +85,13 @@ function Blog({ data, location }) {
           </ResponsiveGrid>
         </SectionHeader>
       )}
-      <Tabs activeIndex={index} onActive={onActive} justify="start" pad="20px">
-        <Tab title={`All (${totalAllBlogsCount})`}>
-          <BlogTabContent
-            key={index}
-            initialPage={data.allBlogs}
-            columns={columns}
-            activeTab={index}
-          />
-        </Tab>
-        <Grommet theme={customTheme}>
-          <Tab
-            pad="none"
-            title={
-              <Menu
-                open={activePlatform}
-                dropProps={{
-                  align: { top: 'bottom', left: 'left' },
-                }}
-                items={platformsData}
-              >
-                <Box
-                  width="115px"
-                  height="48px"
-                  justify="center"
-                  align="center"
-                  direction="row"
-                >
-                  <Text color="black" margin={{ right: 'xsmall' }}>
-                    Platforms
-                  </Text>
-                  <FormDown />
-                </Box>
-              </Menu>
-            }
-          >
-            <BlogTabContent
-              key={platformContent.key}
-              initialPage={platformContent.data}
-              columns={columns}
-              activeTab={index}
-              platform
-            />
-          </Tab>
-        </Grommet>
-        <Tab title={`Open Source (${totalOpenSourceBlogsCount})`}>
-          <BlogTabContent
-            key={index}
-            initialPage={data.openSourceBlogs}
-            columns={columns}
-            activeTab={index}
-          />
-        </Tab>
-        <Tab title="Others">
-          <BlogTabContent
-            key={index}
-            initialPage={data.othersBlogs}
-            columns={columns}
-            activeTab={index}
-          />
-        </Tab>
-      </Tabs>
+      <BlogTabs 
+        data={data} 
+        columns={columns}
+      />
     </Layout>
   );
 }
-
-const blogsPropType = PropTypes.shape({
-  nodes: PropTypes.arrayOf(
-    PropTypes.shape({
-      node: PropTypes.shape({
-        title: PropTypes.string.isRequired,
-        author: PropTypes.string.isRequired,
-        date: PropTypes.string,
-        description: PropTypes.string,
-        authorimage: PropTypes.string,
-      }),
-    }).isRequired,
-  ).isRequired,
-  hasNextPage: PropTypes.bool.isRequired,
-  nextPage: PropTypes.shape({
-    id: PropTypes.string.isRequired,
-  }),
-  collection: PropTypes.shape({
-    id: PropTypes.string.isRequired,
-  }),
-}).isRequired;
 
 Blog.propTypes = {
   data: PropTypes.shape({
@@ -295,24 +118,6 @@ Blog.propTypes = {
         }).isRequired,
       ).isRequired,
     }).isRequired,
-    allBlogs: blogsPropType,
-    openSourceBlogs: blogsPropType,
-    othersBlogs: blogsPropType,
-    allBlogsCount: PropTypes.objectOf(PropTypes.number),
-    openSourceBlogsCount: PropTypes.objectOf(PropTypes.number),
-    ezmeralBlogsCount: PropTypes.objectOf(PropTypes.number),
-    spiffeBlogsCount: PropTypes.objectOf(PropTypes.number),
-    dataFabricBlogsCount: PropTypes.objectOf(PropTypes.number),
-    greenlakeBlogsCount: PropTypes.objectOf(PropTypes.number),
-    chapelBlogsCount: PropTypes.objectOf(PropTypes.number),
-    grommetBlogsCount: PropTypes.objectOf(PropTypes.number),
-    alletraBlogsCount: PropTypes.objectOf(PropTypes.number),
-    deepLearningBlogsCount: PropTypes.objectOf(PropTypes.number),
-    threeParBlogsCount: PropTypes.objectOf(PropTypes.number),
-    nimbleBlogsCount: PropTypes.objectOf(PropTypes.number),
-    oneviewBlogsCount: PropTypes.objectOf(PropTypes.number),
-    oneviewDashboardBlogsCount: PropTypes.objectOf(PropTypes.number),
-    iloBlogsCount: PropTypes.objectOf(PropTypes.number),
   }).isRequired,
   location: PropTypes.shape({
     state: PropTypes.shape({

--- a/src/pages/blog/index.js
+++ b/src/pages/blog/index.js
@@ -28,11 +28,13 @@ function Blog({ data, location }) {
   const siteTitle = siteMetadata.title;
   const [index, setIndex] = React.useState(0);
   const onActive = (nextIndex) => setIndex(nextIndex);
+  const totalAllBlogsCount = data.allBlogsCount.totalCount;
+  const totalOpenSourceBlogsCount = data.openSourceBlogsCount.totalCount;
   // const initialPage = data.allBlogs;
   // const [latestPage, setLatestPage] = useState(initialPage);
   // const [blogPosts, setBlogPosts] = useState(initialPage.nodes);
   // const [collectionId, setCollectionId] = 
-    // useState(initialPage.collection.id);
+  // useState(initialPage.collection.id);
 
   // useEffect(() => {
   //   setCollectionId(initialPage.collection.id);
@@ -119,12 +121,12 @@ function Blog({ data, location }) {
         </SectionHeader>
       )}
       {/* <SectionHeader title="All Blogs"> */}
-      <Tabs 
-        activeIndex={index} 
-        onActive={onActive} 
-        justify="start" 
+      <Tabs
+        activeIndex={index}
+        onActive={onActive}
+        justify="start"
         alignControls="start">
-        <Tab title="All">
+        <Tab title={`All (${totalAllBlogsCount})`}>
           <Box fill pad="large" align="center">
             <OpenSourceTab
               key={index}
@@ -139,7 +141,7 @@ function Blog({ data, location }) {
             Platforms
           </Box>
         </Tab>
-        <Tab title="Open Source">
+        <Tab title={`Open Source (${totalOpenSourceBlogsCount})`}>
           <Box fill pad="large" align="center">
             <OpenSourceTab
               key={index}
@@ -234,6 +236,8 @@ Blog.propTypes = {
         id: PropTypes.string.isRequired,
       }),
     }).isRequired,
+    allBlogsCount: PropTypes.objectOf(PropTypes.string),
+    openSourceBlogsCount: PropTypes.objectOf(PropTypes.string),
   }).isRequired,
   location: PropTypes.shape({
     state: PropTypes.shape({
@@ -246,19 +250,6 @@ export default Blog;
 
 export const pageQuery = graphql`
   query {
-    allBlogs: paginatedCollectionPage(
-      collection: { name: { eq: "blog-posts" } }
-      index: { eq: 0 }
-    ) {
-      nodes
-      hasNextPage
-      nextPage {
-        id
-      }
-      collection {
-        id
-      }
-    }
     featuredblogs: allMarkdownRemark(
       filter: {
         fields: { sourceInstanceName: { eq: "blog" } }
@@ -288,6 +279,39 @@ export const pageQuery = graphql`
             category
           }
         }
+      }
+    }
+    allBlogsCount: allMarkdownRemark(
+      filter: {
+        fields: {sourceInstanceName: {eq: "blog"}}, 
+        frontmatter: {
+          featuredBlog: {ne: true}
+        }
+      }, 
+      sort: {fields: [frontmatter___date], order: DESC}) {
+    totalCount
+    }
+    openSourceBlogsCount: allMarkdownRemark(
+      filter: {
+        fields: {sourceInstanceName: {eq: "blog"}}, 
+        frontmatter: {
+          tags: {eq: "opensource"}
+        }
+      }, 
+      sort: {fields: [frontmatter___date], order: DESC}) {
+    totalCount
+    }
+    allBlogs: paginatedCollectionPage(
+      collection: { name: { eq: "blog-posts" } }
+      index: { eq: 0 }
+    ) {
+      nodes
+      hasNextPage
+      nextPage {
+        id
+      }
+      collection {
+        id
       }
     }
     openSourceBlogs: paginatedCollectionPage(

--- a/src/pages/blog/index.js
+++ b/src/pages/blog/index.js
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { graphql, navigate } from 'gatsby';
-import { Paragraph, Tab, Tabs, Menu } from 'grommet';
+import { Paragraph, Tab, Tabs, Menu, Text } from 'grommet';
+import { FormDown } from 'grommet-icons';
 import {
   BlogCard,
   Layout,
@@ -182,16 +183,22 @@ function Blog({ data, location }) {
           />
         </Tab>
         <Tab
-          plain="true"
           title={
             <Menu
               open={activePlatform}
-              label="Platforms"
               dropProps={{
                 align: { top: 'bottom', left: 'left' },
               }}
               items={platformsData}
-            />
+            >
+              <Text
+                color="black"
+                margin={{ right: 'xsmall' }}
+              >
+                Platforms
+              </Text>
+              <FormDown />
+            </Menu>
           }
         >
           <BlogTabContent

--- a/src/pages/blog/index.js
+++ b/src/pages/blog/index.js
@@ -501,33 +501,6 @@ export const pageQuery = graphql`
         id
       }
     }
-    allPlatformsBlogsCount: allMarkdownRemark(
-      filter: {
-        fields: { sourceInstanceName: { eq: "blog" } }
-        frontmatter: {
-          tags: {
-            in: [
-              "hpe-ezmeral-container-platform"
-              "spiffe-and-spire-projects"
-              "hpe-ezmeral-data-fabric"
-              "hpe-greenlake"
-              "chapel"
-              "grommet"
-              "hpe-alletra"
-              "deep-learning-cookbook"
-              "hpe-3par-and-primera"
-              "hpe-nimble-storage"
-              "hpe-oneview"
-              "hpe-oneview-global-dashboard"
-              "ilo"
-            ]
-          }
-        }
-      }
-      sort: { fields: [frontmatter___date], order: DESC }
-    ) {
-      totalCount
-    }
     othersBlogsCount: allMarkdownRemark(
       filter: {
         fields: { sourceInstanceName: { eq: "blog" } }

--- a/src/pages/blog/index.js
+++ b/src/pages/blog/index.js
@@ -85,10 +85,7 @@ function Blog({ data, location }) {
           </ResponsiveGrid>
         </SectionHeader>
       )}
-      <BlogTabs 
-        data={data} 
-        columns={columns}
-      />
+      <BlogTabs data={data} columns={columns} />
     </Layout>
   );
 }

--- a/src/pages/blog/index.js
+++ b/src/pages/blog/index.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { graphql } from 'gatsby';
-import { Box, Paragraph, Tab, Tabs } from 'grommet';
+import { Box, Paragraph, Tab, Tabs, DropButton } from 'grommet';
+import { FormDown } from 'grommet-icons';
 import {
   BlogCard,
   Layout,
@@ -33,7 +34,7 @@ function Blog({ data, location }) {
   // const initialPage = data.allBlogs;
   // const [latestPage, setLatestPage] = useState(initialPage);
   // const [blogPosts, setBlogPosts] = useState(initialPage.nodes);
-  // const [collectionId, setCollectionId] = 
+  // const [collectionId, setCollectionId] =
   // useState(initialPage.collection.id);
 
   // useEffect(() => {
@@ -87,7 +88,6 @@ function Blog({ data, location }) {
   //   setBlogPosts((state) => [...state, ...json.nodes]);
   //   setLatestPage(json);
 
-
   // }, [latestPage, collectionId ]);
 
   return (
@@ -125,7 +125,8 @@ function Blog({ data, location }) {
         activeIndex={index}
         onActive={onActive}
         justify="start"
-        alignControls="start">
+        alignControls="start"
+      >
         <Tab title={`All (${totalAllBlogsCount})`}>
           <Box fill pad="large" align="center">
             <OpenSourceTab
@@ -136,11 +137,36 @@ function Blog({ data, location }) {
             />
           </Box>
         </Tab>
-        <Tab title="Platforms">
-          <Box fill pad="large" align="center">
-            Platforms
-          </Box>
-        </Tab>
+
+        <DropButton
+          dropAlign={{ top: 'bottom', right: 'right' }}
+          dropContent={
+            <Box pad="small">
+              <Tab
+                title={`HPE Ezmeral Container Platform (${totalAllBlogsCount})`}
+                plain="false"
+              >
+                <Box fill pad="large" align="center">
+                  <OpenSourceTab
+                    key={index}
+                    initialPage={data.allBlogs}
+                    columns={columns}
+                    location={location}
+                  />
+                </Box>
+              </Tab>
+            </Box>
+          }
+          pad={{ vertical: 'small' }}
+          icon={<FormDown />}
+          reverse="true"
+          gap="xsmall"
+          label="Platforms"
+          dropProps={{
+            align: { top: 'bottom', left: 'left' },
+          }}
+        />
+
         <Tab title={`Open Source (${totalOpenSourceBlogsCount})`}>
           <Box fill pad="large" align="center">
             <OpenSourceTab
@@ -283,23 +309,21 @@ export const pageQuery = graphql`
     }
     allBlogsCount: allMarkdownRemark(
       filter: {
-        fields: {sourceInstanceName: {eq: "blog"}}, 
-        frontmatter: {
-          featuredBlog: {ne: true}
-        }
-      }, 
-      sort: {fields: [frontmatter___date], order: DESC}) {
-    totalCount
+        fields: { sourceInstanceName: { eq: "blog" } }
+        frontmatter: { featuredBlog: { ne: true } }
+      }
+      sort: { fields: [frontmatter___date], order: DESC }
+    ) {
+      totalCount
     }
     openSourceBlogsCount: allMarkdownRemark(
       filter: {
-        fields: {sourceInstanceName: {eq: "blog"}}, 
-        frontmatter: {
-          tags: {eq: "opensource"}
-        }
-      }, 
-      sort: {fields: [frontmatter___date], order: DESC}) {
-    totalCount
+        fields: { sourceInstanceName: { eq: "blog" } }
+        frontmatter: { tags: { eq: "opensource" } }
+      }
+      sort: { fields: [frontmatter___date], order: DESC }
+    ) {
+      totalCount
     }
     allBlogs: paginatedCollectionPage(
       collection: { name: { eq: "blog-posts" } }

--- a/src/pages/blog/index.js
+++ b/src/pages/blog/index.js
@@ -1,8 +1,7 @@
-import React, { useState, useCallback, useEffect } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import { graphql, withPrefix, navigate } from 'gatsby';
-import { Box, Button, Paragraph } from 'grommet';
-import { FormDown } from 'grommet-icons';
+import { graphql } from 'gatsby';
+import { Box, Paragraph, Tab, Tabs } from 'grommet';
 import {
   BlogCard,
   Layout,
@@ -11,6 +10,7 @@ import {
   FeaturedBlogCard,
   SectionHeader,
   ResponsiveGrid,
+  OpenSourceTab,
 } from '../../components';
 import { useSiteMetadata } from '../../hooks/use-site-metadata';
 
@@ -22,68 +22,71 @@ const columns = {
 };
 
 function Blog({ data, location }) {
+  console.log('data: ', data);
   const featuredposts = data.featuredblogs.edges;
   const siteMetadata = useSiteMetadata();
   const siteTitle = siteMetadata.title;
+  const [index, setIndex] = React.useState(0);
+  const onActive = (nextIndex) => setIndex(nextIndex);
+  // const initialPage = data.allBlogs;
+  // const [latestPage, setLatestPage] = useState(initialPage);
+  // const [blogPosts, setBlogPosts] = useState(initialPage.nodes);
+  // const [collectionId, setCollectionId] = 
+    // useState(initialPage.collection.id);
 
-  const initialPage = data.paginatedCollectionPage;
-  const [latestPage, setLatestPage] = useState(initialPage);
-  const [blogPosts, setBlogPosts] = useState(initialPage.nodes);
-  const [collectionId, setCollectionId] = useState(initialPage.collection.id);
+  // useEffect(() => {
+  //   setCollectionId(initialPage.collection.id);
 
-  useEffect(() => {
-    setCollectionId(initialPage.collection.id);
+  //   const blogLocalStorage = JSON.parse(localStorage.getItem('blogData'));
 
-    const blogLocalStorage = JSON.parse(localStorage.getItem('blogData'));
+  //   if (
+  //     blogLocalStorage &&
+  //     blogLocalStorage.latestPage &&
+  //     blogLocalStorage.latestBlogPosts
+  //   ) {
+  //     setLatestPage(blogLocalStorage.latestPage);
+  //     setBlogPosts(blogLocalStorage.latestBlogPosts);
+  //   }
 
-    if (
-      blogLocalStorage &&
-      blogLocalStorage.latestPage &&
-      blogLocalStorage.latestBlogPosts
-    ) {
-      setLatestPage(blogLocalStorage.latestPage);
-      setBlogPosts(blogLocalStorage.latestBlogPosts);
-    }
+  //   if (location.state && location.state.isBlogHeaderClicked) {
+  //     navigate('/blog', { replace: true });
+  //     setLatestPage(initialPage);
+  //     setBlogPosts(initialPage.nodes);
+  //     localStorage.removeItem('blogPosition');
+  //     localStorage.removeItem('blogData');
+  //   }
+  // }, [initialPage, location]);
 
-    if (location.state && location.state.isBlogHeaderClicked) {
-      navigate('/blog', { replace: true });
-      setLatestPage(initialPage);
-      setBlogPosts(initialPage.nodes);
-      localStorage.removeItem('blogPosition');
-      localStorage.removeItem('blogData');
-    }
-  }, [initialPage, location]);
+  // useEffect(() => {
+  //   const scrollPosition = JSON.parse(localStorage.getItem('blogPosition'));
 
-  useEffect(() => {
-    const scrollPosition = JSON.parse(localStorage.getItem('blogPosition'));
+  //   if (scrollPosition) {
+  //     setTimeout(() => {
+  //       window.scrollTo
+  // ({ top: scrollPosition, left: 0, behavior: 'smooth' });
+  //     }, 100);
+  //   }
+  // }, []);
 
-    if (scrollPosition) {
-      setTimeout(() => {
-        window.scrollTo({ top: scrollPosition, left: 0, behavior: 'smooth' });
-      }, 100);
-    }
-  }, []);
+  // const loadNextPage = useCallback(async (latestPage, collectionId) => {
+  //   if (!latestPage.hasNextPage) return;
+  //   const nextPageId = latestPage.nextPage.id;
+  //   console.log('collectionId: ', collectionId);
+  //   console.log('nextPageId: ', nextPageId);
+  //   const path = withPrefix(
+  //     `/paginated-data/${collectionId}/${nextPageId}.json`,
+  //   );
+  //   console.log('path: ', path);
+  //   const res = await fetch(path);
+  //   const json = await res.json();
+  //   console.log('res: ', res);
+  //   console.log('json: ', json);
 
-  const loadNextPage = useCallback(async () => {
-    if (!latestPage.hasNextPage) return;
-    const nextPageId = latestPage.nextPage.id;
-    const path = withPrefix(
-      `/paginated-data/${collectionId}/${nextPageId}.json`,
-    );
-    const res = await fetch(path);
-    const json = await res.json();
+  //   setBlogPosts((state) => [...state, ...json.nodes]);
+  //   setLatestPage(json);
 
-    setBlogPosts((state) => [...state, ...json.nodes]);
-    setLatestPage(json);
 
-    localStorage.setItem(
-      'blogData',
-      JSON.stringify({
-        latestBlogPosts: [...blogPosts, ...json.nodes],
-        latestPage: json,
-      }),
-    );
-  }, [latestPage, collectionId, blogPosts]);
+  // }, [latestPage, collectionId ]);
 
   return (
     <Layout title={siteTitle}>
@@ -108,24 +111,52 @@ function Blog({ data, location }) {
           />
           <ResponsiveGrid rows={{}} columns={columns}>
             {featuredposts.map(
-              ({ node }, index) =>
+              ({ node }, i) =>
                 node.fields.slug !== '/' &&
-                index > 0 && <BlogCard key={node.id} node={node} />,
+                i > 0 && <BlogCard key={node.id} node={node} />,
             )}
           </ResponsiveGrid>
         </SectionHeader>
       )}
-      <SectionHeader title="All Blogs">
-        <ResponsiveGrid rows={{}} columns={columns}>
-          {blogPosts.map(
-            (blogPost) =>
-              blogPost.url !== '/' && (
-                <BlogCard key={blogPost.id} node={blogPost} />
-              ),
-          )}
-        </ResponsiveGrid>
-      </SectionHeader>
-      <Box align="center" pad="medium">
+      {/* <SectionHeader title="All Blogs"> */}
+      <Tabs 
+        activeIndex={index} 
+        onActive={onActive} 
+        justify="start" 
+        alignControls="start">
+        <Tab title="All">
+          <Box fill pad="large" align="center">
+            <OpenSourceTab
+              key={index}
+              initialPage={data.allBlogs}
+              columns={columns}
+              location={location}
+            />
+          </Box>
+        </Tab>
+        <Tab title="Platforms">
+          <Box fill pad="large" align="center">
+            Platforms
+          </Box>
+        </Tab>
+        <Tab title="Open Source">
+          <Box fill pad="large" align="center">
+            <OpenSourceTab
+              key={index}
+              initialPage={data.openSourceBlogs}
+              columns={columns}
+              location={location}
+            />
+          </Box>
+        </Tab>
+        <Tab title="Others">
+          <Box fill pad="large" align="center">
+            Open Source
+          </Box>
+        </Tab>
+      </Tabs>
+      {/* </SectionHeader> */}
+      {/* <Box align="center" pad="medium">
         <Button
           icon={<FormDown />}
           hoverIndicator
@@ -133,7 +164,7 @@ function Blog({ data, location }) {
           onClick={loadNextPage}
           label="Load More"
         />
-      </Box>
+      </Box> */}
     </Layout>
   );
 }
@@ -163,7 +194,27 @@ Blog.propTypes = {
         }).isRequired,
       ).isRequired,
     }).isRequired,
-    paginatedCollectionPage: PropTypes.shape({
+    allBlogs: PropTypes.shape({
+      nodes: PropTypes.arrayOf(
+        PropTypes.shape({
+          node: PropTypes.shape({
+            title: PropTypes.string.isRequired,
+            author: PropTypes.string.isRequired,
+            date: PropTypes.string,
+            description: PropTypes.string,
+            authorimage: PropTypes.string,
+          }),
+        }).isRequired,
+      ).isRequired,
+      hasNextPage: PropTypes.bool.isRequired,
+      nextPage: PropTypes.shape({
+        id: PropTypes.string.isRequired,
+      }),
+      collection: PropTypes.shape({
+        id: PropTypes.string.isRequired,
+      }),
+    }).isRequired,
+    openSourceBlogs: PropTypes.shape({
       nodes: PropTypes.arrayOf(
         PropTypes.shape({
           node: PropTypes.shape({
@@ -195,7 +246,7 @@ export default Blog;
 
 export const pageQuery = graphql`
   query {
-    paginatedCollectionPage(
+    allBlogs: paginatedCollectionPage(
       collection: { name: { eq: "blog-posts" } }
       index: { eq: 0 }
     ) {
@@ -237,6 +288,19 @@ export const pageQuery = graphql`
             category
           }
         }
+      }
+    }
+    openSourceBlogs: paginatedCollectionPage(
+      collection: { name: { eq: "opensource-blog-posts" } }
+      index: { eq: 0 }
+    ) {
+      nodes
+      hasNextPage
+      nextPage {
+        id
+      }
+      collection {
+        id
       }
     }
   }

--- a/src/pages/blog/index.js
+++ b/src/pages/blog/index.js
@@ -1,8 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { graphql, navigate } from 'gatsby';
-import { Paragraph, Tab, Tabs, Menu, Text } from 'grommet';
+import { Paragraph, Tab, Tabs, Menu, Text, Grommet, Box } from 'grommet';
 import { FormDown } from 'grommet-icons';
+import { hpe } from 'grommet-theme-hpe';
+import { deepMerge } from 'grommet/utils';
 import {
   BlogCard,
   Layout,
@@ -15,6 +17,15 @@ import {
 } from '../../components';
 import { useSiteMetadata } from '../../hooks/use-site-metadata';
 import { useLocalStorage } from '../../hooks/use-local-storage';
+
+const customTheme = deepMerge(hpe, {
+  tab: {
+    pad: {
+      vertical: '0',
+      horizontal: '0',
+    },
+  },
+});
 
 const columns = {
   small: 'auto',
@@ -182,33 +193,41 @@ function Blog({ data, location }) {
             activeTab={index}
           />
         </Tab>
-        <Tab
-          title={
-            <Menu
-              open={activePlatform}
-              dropProps={{
-                align: { top: 'bottom', left: 'left' },
-              }}
-              items={platformsData}
-            >
-              <Text
-                color="black"
-                margin={{ right: 'xsmall' }}
+        <Grommet theme={customTheme}>
+          <Tab
+            pad="none"
+            title={
+              <Menu
+                open={activePlatform}
+                dropProps={{
+                  align: { top: 'bottom', left: 'left' },
+                }}
+                items={platformsData}
               >
-                Platforms
-              </Text>
-              <FormDown />
-            </Menu>
-          }
-        >
-          <BlogTabContent
-            key={platformContent.key}
-            initialPage={platformContent.data}
-            columns={columns}
-            activeTab={index}
-            platform
-          />
-        </Tab>
+                <Box
+                  width="115px"
+                  height="48px"
+                  justify="center"
+                  align="center"
+                  direction="row"
+                >
+                  <Text color="black" margin={{ right: 'xsmall' }}>
+                    Platforms
+                  </Text>
+                  <FormDown />
+                </Box>
+              </Menu>
+            }
+          >
+            <BlogTabContent
+              key={platformContent.key}
+              initialPage={platformContent.data}
+              columns={columns}
+              activeTab={index}
+              platform
+            />
+          </Tab>
+        </Grommet>
         <Tab title={`Open Source (${totalOpenSourceBlogsCount})`}>
           <BlogTabContent
             key={index}

--- a/src/pages/blog/index.js
+++ b/src/pages/blog/index.js
@@ -30,8 +30,10 @@ function Blog({ data, location }) {
   const onActive = (nextIndex) => setIndex(nextIndex);
   const totalAllBlogsCount = data.allBlogsCount.totalCount;
   const totalOpenSourceBlogsCount = data.openSourceBlogsCount.totalCount;
-  const [platformContent, setPlatformContent] = 
-    useState({ key: 0, data: data.allBlogs });
+  const [platformContent, setPlatformContent] = useState({
+    key: 0,
+    data: data.allBlogs,
+  });
   /* eslint-disable-next-line no-unused-vars */
   const [blogPosition, setBlogPosition] = useLocalStorage('blogPosition');
   const [activeBlogTab, setActiveBlogTab] = useLocalStorage('activeBlogTab');
@@ -46,10 +48,54 @@ function Blog({ data, location }) {
       label: 'Spiffee and Spire Projects',
       count: data.spiffeBlogsCount.totalCount,
     },
+    dataFabricBlogs: {
+      label: 'HPE Ezmeral Data Fabric',
+      count: data.dataFabricBlogsCount.totalCount,
+    },
+    greenlakeBlogs: {
+      label: 'HPE GreenLake',
+      count: data.greenlakeBlogsCount.totalCount,
+    },
+    chapelBlogs: {
+      label: 'Chapel',
+      count: data.chapelBlogsCount.totalCount,
+    },
+    grommetBlogs: {
+      label: 'Grommet',
+      count: data.grommetBlogsCount.totalCount,
+    },
+    alletraBlogs: {
+      label: 'HPE Alletra',
+      count: data.alletraBlogsCount.totalCount,
+    },
+    deepLearningBlogs: {
+      label: 'HPE Deep Learning Cookbook',
+      count: data.deepLearningBlogsCount.totalCount,
+    },
+    threeParBlogs: {
+      label: 'HPE 3PAR and Primera',
+      count: data.threeParBlogsCount.totalCount,
+    },
+    nimbleBlogs: {
+      label: 'HPE Nimble Storage',
+      count: data.nimbleBlogsCount.totalCount,
+    },
+    oneviewBlogs: {
+      label: 'HPE OneView',
+      count: data.oneviewBlogsCount.totalCount,
+    },
+    oneviewDashboardBlogs: {
+      label: 'HPE OneView Global Dashboard',
+      count: data.oneviewDashboardBlogsCount.totalCount,
+    },
+    iloBlogs: {
+      label: 'iLO RESTful API',
+      count: data.iloBlogsCount.totalCount,
+    },
   };
 
   const platformsData = Object.entries(data)
-    .filter(item => Object.prototype.hasOwnProperty.call(platforms, (item[0])))
+    .filter((item) => Object.prototype.hasOwnProperty.call(platforms, item[0]))
     .map((item, i) => {
       return {
         label: `${platforms[item[0]].label} (${platforms[item[0]].count})`,
@@ -76,7 +122,6 @@ function Blog({ data, location }) {
       localStorage.removeItem('blogPosition');
       localStorage.removeItem('blogData');
       localStorage.removeItem('activeBlogTab');
-
     }
   }, [dropDownData, activeBlogTab, location]);
 
@@ -124,13 +169,7 @@ function Blog({ data, location }) {
           </ResponsiveGrid>
         </SectionHeader>
       )}
-      <Tabs
-        activeIndex={index}
-        onActive={onActive}
-        justify="start"
-        alignControls="start"
-        pad="20px"
-      >
+      <Tabs activeIndex={index} onActive={onActive} justify="start" pad="20px">
         <Tab title={`All (${totalAllBlogsCount})`}>
           <BlogTabContent
             key={index}
@@ -167,7 +206,14 @@ function Blog({ data, location }) {
             activeTab={index}
           />
         </Tab>
-        <Tab title="Others" key={index}>Others</Tab>
+        <Tab title="Others" key={index}>
+          <BlogTabContent
+            key={index}
+            initialPage={data.othersBlogs}
+            columns={columns}
+            activeTab={index}
+          />
+        </Tab>
       </Tabs>
     </Layout>
   );
@@ -221,12 +267,22 @@ Blog.propTypes = {
     }).isRequired,
     allBlogs: blogsPropType,
     openSourceBlogs: blogsPropType,
-    ezmeralBlogs: blogsPropType,
-    spiffeBlogs: blogsPropType,
+    othersBlogs: blogsPropType,
     allBlogsCount: PropTypes.objectOf(PropTypes.number),
     openSourceBlogsCount: PropTypes.objectOf(PropTypes.number),
     ezmeralBlogsCount: PropTypes.objectOf(PropTypes.number),
     spiffeBlogsCount: PropTypes.objectOf(PropTypes.number),
+    dataFabricBlogsCount: PropTypes.objectOf(PropTypes.number),
+    greenlakeBlogsCount: PropTypes.objectOf(PropTypes.number),
+    chapelBlogsCount: PropTypes.objectOf(PropTypes.number),
+    grommetBlogsCount: PropTypes.objectOf(PropTypes.number),
+    alletraBlogsCount: PropTypes.objectOf(PropTypes.number),
+    deepLearningBlogsCount: PropTypes.objectOf(PropTypes.number),
+    threeParBlogsCount: PropTypes.objectOf(PropTypes.number),
+    nimbleBlogsCount: PropTypes.objectOf(PropTypes.number),
+    oneviewBlogsCount: PropTypes.objectOf(PropTypes.number),
+    oneviewDashboardBlogsCount: PropTypes.objectOf(PropTypes.number),
+    iloBlogsCount: PropTypes.objectOf(PropTypes.number),
   }).isRequired,
   location: PropTypes.shape({
     state: PropTypes.shape({
@@ -292,17 +348,17 @@ export const pageQuery = graphql`
         id
       }
     }
-    spiffeBlogsCount: allMarkdownRemark(
+    dataFabricBlogsCount: allMarkdownRemark(
       filter: {
         fields: { sourceInstanceName: { eq: "blog" } }
-        frontmatter: { tags: { eq: "spiffe-and-spire-projects" } }
+        frontmatter: { tags: { eq: "hpe-ezmeral-data-fabric" } }
       }
       sort: { fields: [frontmatter___date], order: DESC }
     ) {
       totalCount
     }
-    spiffeBlogs: paginatedCollectionPage(
-      collection: { name: { eq: "spiffe-blog-posts" } }
+    dataFabricBlogs: paginatedCollectionPage(
+      collection: { name: { eq: "data-fabric-posts" } }
       index: { eq: 0 }
     ) {
       nodes
@@ -336,6 +392,248 @@ export const pageQuery = graphql`
         id
       }
     }
+    greenlakeBlogsCount: allMarkdownRemark(
+      filter: {
+        fields: { sourceInstanceName: { eq: "blog" } }
+        frontmatter: { tags: { eq: "hpe-greenlake" } }
+      }
+      sort: { fields: [frontmatter___date], order: DESC }
+    ) {
+      totalCount
+    }
+    greenlakeBlogs: paginatedCollectionPage(
+      collection: { name: { eq: "greenlake-posts" } }
+      index: { eq: 0 }
+    ) {
+      nodes
+      hasNextPage
+      nextPage {
+        id
+      }
+      collection {
+        id
+      }
+    }
+    spiffeBlogsCount: allMarkdownRemark(
+      filter: {
+        fields: { sourceInstanceName: { eq: "blog" } }
+        frontmatter: { tags: { eq: "spiffe-and-spire-projects" } }
+      }
+      sort: { fields: [frontmatter___date], order: DESC }
+    ) {
+      totalCount
+    }
+    spiffeBlogs: paginatedCollectionPage(
+      collection: { name: { eq: "spiffe-blog-posts" } }
+      index: { eq: 0 }
+    ) {
+      nodes
+      hasNextPage
+      nextPage {
+        id
+      }
+      collection {
+        id
+      }
+    }
+    chapelBlogsCount: allMarkdownRemark(
+      filter: {
+        fields: { sourceInstanceName: { eq: "blog" } }
+        frontmatter: { tags: { eq: "chapel" } }
+      }
+      sort: { fields: [frontmatter___date], order: DESC }
+    ) {
+      totalCount
+    }
+    chapelBlogs: paginatedCollectionPage(
+      collection: { name: { eq: "chapel-posts" } }
+      index: { eq: 0 }
+    ) {
+      nodes
+      hasNextPage
+      nextPage {
+        id
+      }
+      collection {
+        id
+      }
+    }
+    grommetBlogsCount: allMarkdownRemark(
+      filter: {
+        fields: { sourceInstanceName: { eq: "blog" } }
+        frontmatter: { tags: { eq: "grommet" } }
+      }
+      sort: { fields: [frontmatter___date], order: DESC }
+    ) {
+      totalCount
+    }
+    grommetBlogs: paginatedCollectionPage(
+      collection: { name: { eq: "grommet-posts" } }
+      index: { eq: 0 }
+    ) {
+      nodes
+      hasNextPage
+      nextPage {
+        id
+      }
+      collection {
+        id
+      }
+    }
+    alletraBlogsCount: allMarkdownRemark(
+      filter: {
+        fields: { sourceInstanceName: { eq: "blog" } }
+        frontmatter: { tags: { eq: "hpe-alletra" } }
+      }
+      sort: { fields: [frontmatter___date], order: DESC }
+    ) {
+      totalCount
+    }
+    alletraBlogs: paginatedCollectionPage(
+      collection: { name: { eq: "alletra-posts" } }
+      index: { eq: 0 }
+    ) {
+      nodes
+      hasNextPage
+      nextPage {
+        id
+      }
+      collection {
+        id
+      }
+    }
+    deepLearningBlogsCount: allMarkdownRemark(
+      filter: {
+        fields: { sourceInstanceName: { eq: "blog" } }
+        frontmatter: { tags: { eq: "deep-learning-cookbook" } }
+      }
+      sort: { fields: [frontmatter___date], order: DESC }
+    ) {
+      totalCount
+    }
+    deepLearningBlogs: paginatedCollectionPage(
+      collection: { name: { eq: "deep-learning-posts" } }
+      index: { eq: 0 }
+    ) {
+      nodes
+      hasNextPage
+      nextPage {
+        id
+      }
+      collection {
+        id
+      }
+    }
+    threeParBlogsCount: allMarkdownRemark(
+      filter: {
+        fields: { sourceInstanceName: { eq: "blog" } }
+        frontmatter: { tags: { eq: "hpe-3par-and-primera" } }
+      }
+      sort: { fields: [frontmatter___date], order: DESC }
+    ) {
+      totalCount
+    }
+    threeParBlogs: paginatedCollectionPage(
+      collection: { name: { eq: "3par-posts" } }
+      index: { eq: 0 }
+    ) {
+      nodes
+      hasNextPage
+      nextPage {
+        id
+      }
+      collection {
+        id
+      }
+    }
+    nimbleBlogsCount: allMarkdownRemark(
+      filter: {
+        fields: { sourceInstanceName: { eq: "blog" } }
+        frontmatter: { tags: { eq: "hpe-nimble-storage" } }
+      }
+      sort: { fields: [frontmatter___date], order: DESC }
+    ) {
+      totalCount
+    }
+    nimbleBlogs: paginatedCollectionPage(
+      collection: { name: { eq: "nimble-posts" } }
+      index: { eq: 0 }
+    ) {
+      nodes
+      hasNextPage
+      nextPage {
+        id
+      }
+      collection {
+        id
+      }
+    }
+    oneviewBlogsCount: allMarkdownRemark(
+      filter: {
+        fields: { sourceInstanceName: { eq: "blog" } }
+        frontmatter: { tags: { eq: "hpe-oneview" } }
+      }
+      sort: { fields: [frontmatter___date], order: DESC }
+    ) {
+      totalCount
+    }
+    oneviewBlogs: paginatedCollectionPage(
+      collection: { name: { eq: "oneview-posts" } }
+      index: { eq: 0 }
+    ) {
+      nodes
+      hasNextPage
+      nextPage {
+        id
+      }
+      collection {
+        id
+      }
+    }
+    oneviewDashboardBlogsCount: allMarkdownRemark(
+      filter: {
+        fields: { sourceInstanceName: { eq: "blog" } }
+        frontmatter: { tags: { eq: "hpe-oneview-global-dashboard" } }
+      }
+      sort: { fields: [frontmatter___date], order: DESC }
+    ) {
+      totalCount
+    }
+    oneviewDashboardBlogs: paginatedCollectionPage(
+      collection: { name: { eq: "oneview-dashboard-posts" } }
+      index: { eq: 0 }
+    ) {
+      nodes
+      hasNextPage
+      nextPage {
+        id
+      }
+      collection {
+        id
+      }
+    }
+    iloBlogsCount: allMarkdownRemark(
+      filter: {
+        fields: { sourceInstanceName: { eq: "blog" } }
+        frontmatter: { tags: { eq: "ilo" } }
+      }
+      sort: { fields: [frontmatter___date], order: DESC }
+    ) {
+      totalCount
+    }
+    iloBlogs: paginatedCollectionPage(
+      collection: { name: { eq: "ilo-posts" } }
+      index: { eq: 0 }
+    ) {
+      nodes
+      hasNextPage
+      nextPage {
+        id
+      }
+      collection {
+        id
+      }
+    }
     openSourceBlogsCount: allMarkdownRemark(
       filter: {
         fields: { sourceInstanceName: { eq: "blog" } }
@@ -347,6 +645,19 @@ export const pageQuery = graphql`
     }
     openSourceBlogs: paginatedCollectionPage(
       collection: { name: { eq: "opensource-blog-posts" } }
+      index: { eq: 0 }
+    ) {
+      nodes
+      hasNextPage
+      nextPage {
+        id
+      }
+      collection {
+        id
+      }
+    }
+    othersBlogs: paginatedCollectionPage(
+      collection: { name: { eq: "others-posts" } }
       index: { eq: 0 }
     ) {
       nodes

--- a/src/pages/blog/index.js
+++ b/src/pages/blog/index.js
@@ -38,6 +38,7 @@ function Blog({ data, location }) {
   const [blogPosition, setBlogPosition] = useLocalStorage('blogPosition');
   const [activeBlogTab, setActiveBlogTab] = useLocalStorage('activeBlogTab');
   const [dropDownData, setDropDownData] = useLocalStorage('dropDownData');
+  const [activePlatform, setActivePlatform] = useLocalStorage('activePlatform');
 
   const platforms = {
     ezmeralBlogs: {
@@ -99,10 +100,12 @@ function Blog({ data, location }) {
     .map((item, i) => {
       return {
         label: `${platforms[item[0]].label} (${platforms[item[0]].count})`,
+        active: platforms[item[0]].label === activePlatform,
         onClick: () => {
           setActiveBlogTab(index);
           setDropDownData(item[1]);
           setPlatformContent({ key: i, data: item[1] });
+          setActivePlatform(platforms[item[0]].label);
         },
       };
     });
@@ -182,6 +185,7 @@ function Blog({ data, location }) {
           plain="false"
           title={
             <Menu
+              open={activePlatform}
               label="Platforms"
               dropProps={{
                 align: { top: 'bottom', left: 'left' },

--- a/src/pages/blog/index.js
+++ b/src/pages/blog/index.js
@@ -182,7 +182,7 @@ function Blog({ data, location }) {
           />
         </Tab>
         <Tab
-          plain="false"
+          plain="true"
           title={
             <Menu
               open={activePlatform}
@@ -210,7 +210,7 @@ function Blog({ data, location }) {
             activeTab={index}
           />
         </Tab>
-        <Tab title="Others" key={index}>
+        <Tab title="Others">
           <BlogTabContent
             key={index}
             initialPage={data.othersBlogs}


### PR DESCRIPTION
## Issue
Issue: https://github.com/hpe-dev-incubator/hpe-dev-portal/issues/577
- User should be able to filter blogs by All, Platforms, Open Source, and others
- Clicking on "Platforms" should display dropdown of items
- When a blog is selected, going back to the blog page by either the browser back button or the "Go to Blog Page" at the bottom, should direct user back to the previous spot/location on the blog page. 
- When a blog is selected, going back to the blog page by either the browser back button or the "Go to Blog Page" at the bottom and if "Load More" button is selected,  it should direct user back to the previous spot/location with the loaded more blog cards.
-  When a blog is selected, going back to the blog page by either the browser back button or the "Go to Blog Page" at the bottom, the selected/active tab should be highlighted.

## Proposed Changes
- Used previously installed "gatsby-plugin-paginated-collection" to paginate each category in `gatsby-config.js` and `gatsby-node.js`
- Create `useLocalStorage` hook to persist blog page data when user goes back to the blog page from an individual blog. 
- Use Grommet `Tabs` and `Menu` components to create filter interface

## Test
