### PR TITLE
Use thumbnail image as og:image if provided

### DIFF
--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -46,7 +46,17 @@ const rows = {
   xlarge: ['auto'],
 };
 
-const findImageURL = (body) => {
+const findThumbnailImage = (thumbnailimage) => {
+  if (thumbnailimage) {
+    const imageURL = thumbnailimage.includes('https://')
+      ? thumbnailimage
+      : `https://developer.hpe.com${thumbnailimage}`;
+    return imageURL;
+  }
+  return null;
+};
+
+const findFirstImgInBody = (body) => {
   const foundImageByRegex =
     /!\[[^\]]*\]\((?<filename>.*?)(?="|\))(?<optionalpart>".*")?\)/gi.exec(
       body,
@@ -55,7 +65,6 @@ const findImageURL = (body) => {
     const imageURL = foundImageByRegex[1].includes('https://')
       ? foundImageByRegex[1]
       : `https://developer.hpe.com${foundImageByRegex[1]}`;
-
     return imageURL;
   }
   return null;
@@ -89,6 +98,7 @@ function BlogPostTemplate({ data }) {
     author,
     tags,
     authorimage,
+    thumbnailimage,
   } = post.frontmatter;
 
   return (
@@ -96,7 +106,10 @@ function BlogPostTemplate({ data }) {
       <SEO
         title={title}
         description={stripDescription(description || excerpt)}
-        image={findImageURL(rawMarkdownBody)}
+        image={
+          findThumbnailImage(thumbnailimage) ||
+          findFirstImgInBody(rawMarkdownBody)
+        }
       />
       <Box flex overflow="auto" gap="medium" pad="small">
         <Box direction="row-responsive">
@@ -185,6 +198,7 @@ BlogPostTemplate.propTypes = {
         description: PropTypes.string,
         tags: PropTypes.arrayOf(PropTypes.string),
         authorimage: PropTypes.string.isRequired,
+        thumbnailimage: PropTypes.string,
       }).isRequired,
     }).isRequired,
     blogsByTags: PropTypes.shape({


### PR DESCRIPTION
Issue: https://github.com/hpe-dev-incubator/hpe-dev-portal/issues/942

If blog editor adds a local image path(/img/abc.png) or external link(https://abc.com/abc.png) in the Blog CMS `THUMBNAIL IMAGE(OPTIONAL)` input, it will be used as og:image first before using the first image in the blog body. 

### How to Test
You can find the `og:image` through the following steps:
1. Go on a blog page
2. Open browser developer tools
3. Click on Elements Tab
4. Expand `<head>` tag
5. Look for `<meta>` tag with `name` property `og:image` or `twitter:image`
6. The `content` property should show thumbnail image url for blogs that have provided a thumbnail image in CMS

Below are a couple of blogs that already have thumbnail image provide:
- KubeCon + CloudNativeCon, Europe: Be Involved via this Virtual Opportunity
- Mapping Kubernetes Services to HPE Ezmeral Runtime Enterprise Gateway
- Implementing OAuth 2 Flow for Data Services Cloud Console's Client
  Application 


