### PR TITLE
Jan 2022 Munch n Lunch event card still showing after pass due

### DIFF
--- a/content/event/hpe-dev-munch-learn-series-january-2022.md
+++ b/content/event/hpe-dev-munch-learn-series-january-2022.md
@@ -1,7 +1,7 @@
 ---
 title: HPE DEV Munch & Learn series January 2022
 dateStart: 2022-01-19T16:00:05.628Z
-dateEnd: 2022-01-19T17:15:05.665Z
+dateEnd: 2022-01-19T17:20:05.665Z
 category: Virtual Event
 image: /img/munch-and-learn-event-card-white.jpg
 link: https://hpe.zoom.us/webinar/register/WN_JLPveMmYSOWd1Mn-7bU62Q


### PR DESCRIPTION
### Issue
Jan 2022 Munch and Learn event still showing as Upcoming on event page

### Proposed Change
Update the event End Time to 5 minutes