### PR TITLE
fix: workshop registration panel and deep-link improvements

### DIFF
--- a/src/components/WorkshopsOnDemandSection/index.js
+++ b/src/components/WorkshopsOnDemandSection/index.js
@@ -151,7 +151,8 @@ const WorkshopsOnDemandSection = () => {
               workshop.description && workshop.description.length > 130
                 ? `${workshop.description.slice(0, 130).trimEnd()}…`
                 : workshop.description || '';
-            const detailLink = workshop.replayId
+            const registerLink = `/hackshack/workshops?id=${workshop.id}`;
+            const replayLink = workshop.replayId
               ? `/hackshack/workshop/${workshop.replayId}`
               : '/hackshack/workshops';
             const isFull = workshop.location === 'FULL';
@@ -282,9 +283,7 @@ const WorkshopsOnDemandSection = () => {
                       }}
                     >
                       <Anchor
-                        href={workshop.replayLink || detailLink}
-                        target="_blank"
-                        rel="noreferrer noopener"
+                        href={registerLink}
                         icon={<LinkNext size="small" />}
                         label="Register"
                         reverse
@@ -292,10 +291,12 @@ const WorkshopsOnDemandSection = () => {
                         style={{ fontWeight: 500, fontSize: '16px' }}
                       />
                       <Anchor
-                        href={detailLink}
+                        href={replayLink}
                         target="_blank"
                         rel="noreferrer noopener"
-                        label="Learn more"
+                        label={
+                          workshop.replayLink ? 'Watch replay' : 'Learn more'
+                        }
                         style={{
                           color: '#292d3a',
                           fontWeight: 500,

--- a/src/components/hackshack/Card/ScheduleCard.js
+++ b/src/components/hackshack/Card/ScheduleCard.js
@@ -285,44 +285,38 @@ export const SignupLayer = ({
   return (
     <Layer
       position="right"
-      full={size === 'large' ? true : 'vertical'}
-      style={{ borderRadius: '4px 0px 0px 4px' }}
-      background={
-        size === 'large'
-          ? {
-              image: 'url(/img/hackshack/gremlin-signup.png)',
-              size: 'cover',
-              position: 'center',
-              repeat: 'no-repeat',
-              opacity: '0.99',
-            }
-          : {
-              color: '#333333',
-            }
-      }
+      full="vertical"
+      modal={false}
+      onClickOutside={() => setLayer(false)}
+      onEsc={() => setLayer(false)}
+      style={{
+        borderRadius: '4px 0px 0px 4px',
+        top: '80px',
+        height: 'calc(100vh - 80px)',
+        boxShadow: '-4px 0 16px rgba(0,0,0,0.15)',
+      }}
     >
-      <Button
-        onClick={() => {
-          // reset();
-          setLayer(false);
-        }}
-        alignSelf="end"
-        icon={<FormClose />}
-        margin={{ top: 'medium', right: 'medium' }}
-      />
       <Box
-        overflow="auto"
-        height="950px"
+        background="white"
+        height="100%"
         width={size === 'small' ? '100%' : '500px'}
         direction="column"
-        pad={{ bottom: 'large', left: 'xlarge', right: 'xlarge' }}
-        margin={size === 'large' ? { right: '100px' } : { right: '0' }}
+        pad={{ top: 'medium', bottom: 'large', horizontal: 'large' }}
+        overflow="auto"
         alignSelf="end"
       >
-        <Heading color="#ffffff" margin={{ top: 'none', bottom: 'small' }}>
-          Register
-        </Heading>
-        <Text color="#ffffff" margin={{ top: 'none', bottom: 'small' }}>
+        <Box
+          direction="row"
+          justify="between"
+          align="center"
+          margin={{ bottom: 'small' }}
+        >
+          <Heading level={3} margin="none">
+            Register
+          </Heading>
+          <Button onClick={() => setLayer(false)} icon={<FormClose />} plain />
+        </Box>
+        <Text margin={{ bottom: 'medium' }}>
           {title} {sessionType === 'Workshops-on-Demand' ? 'workshop' : ''}
         </Text>
         <Form
@@ -465,6 +459,7 @@ export const SignupLayer = ({
               justify="center"
               margin={{ top: 'medium' }}
               background="status-critical"
+              round="xsmall"
             >
               <Text alignSelf="center">{error.message}</Text>
             </Box>
@@ -498,72 +493,57 @@ export const SuccessLayer = ({
 }) => (
   <Layer
     position="right"
-    full={size === 'large' ? true : 'vertical'}
-    style={{ borderRadius: '4px 0px 0px 4px' }}
-    background={
-      size === 'large'
-        ? {
-            image: 'url(/img/hackshack/gremlin-signup.png)',
-            size: 'cover',
-            position: 'center',
-            repeat: 'no-repeat',
-            opacity: '0.99',
-          }
-        : {
-            color: '#333333',
-          }
-    }
+    full="vertical"
+    modal={false}
+    onClickOutside={() => setLayer(false)}
+    onEsc={() => setLayer(false)}
+    style={{
+      borderRadius: '4px 0px 0px 4px',
+      top: '80px',
+      height: 'calc(100vh - 80px)',
+      boxShadow: '-4px 0 16px rgba(0,0,0,0.15)',
+    }}
   >
-    <Button
-      alignSelf="end"
-      onClick={() => setLayer(false)}
-      icon={<FormClose />}
-      margin={{ top: 'medium', right: 'medium' }}
-    />
     <Box
+      background="white"
       height="100%"
       width={size === 'small' ? '100%' : '500px'}
       direction="column"
-      pad={{ bottom: 'large', left: 'xlarge', right: 'xlarge' }}
+      pad={{ top: 'medium', bottom: 'large', horizontal: 'large' }}
+      overflow="auto"
       alignSelf="end"
     >
-      <StatusGood size="large" />
-      <Box margin={{ bottom: 'medium', top: 'small' }}>
-        <Heading color="#ffffff" margin={{ top: 'none', bottom: 'small' }}>
-          {sessionType === 'Coding Challenge'
-            ? 'Challenge Accepted!'
-            : "You're Registered!"}
-        </Heading>
-        <Text color="#ffffff">
-          You have been signed up for this{' '}
-          {sessionType === 'Coding Challenge' ? 'Challenge' : 'workshop'}. Head
-          over to your email ({email}) to learn what happens next.
-        </Text>
+      <Box
+        direction="row"
+        justify="between"
+        align="center"
+        margin={{ bottom: 'medium' }}
+      >
+        <Box direction="row" align="center" gap="small">
+          <StatusGood color="status-ok" size="medium" />
+          <Heading level={3} margin="none">
+            {sessionType === 'Coding Challenge'
+              ? 'Challenge Accepted!'
+              : "You're Registered!"}
+          </Heading>
+        </Box>
+        <Button onClick={() => setLayer(false)} icon={<FormClose />} plain />
       </Box>
-      <Box>
-        <Text>Your registration info:</Text>
-        <Text>
-          {' '}
-          <Text color="#ffffff" weight="bold">
-            {name}
-          </Text>{' '}
-          is signed up for{' '}
-          <Text color="#ffffff" weight="bold">
-            {title}
-          </Text>
-        </Text>
-      </Box>
-      <Box margin={{ top: 'large' }}>
-        <Button
-          alignSelf="start"
-          label="close"
-          onClick={() => {
-            // reset();
-            setLayer(false);
-          }}
-          primary
-        />
-      </Box>
+      <Text margin={{ bottom: 'small' }}>
+        You have been signed up for this{' '}
+        {sessionType === 'Coding Challenge' ? 'Challenge' : 'workshop'}. Head
+        over to your email ({email}) to learn what happens next.
+      </Text>
+      <Text margin={{ bottom: 'medium' }}>
+        <Text weight="bold">{name}</Text> is signed up for{' '}
+        <Text weight="bold">{title}</Text>
+      </Text>
+      <Button
+        alignSelf="start"
+        label="Close"
+        onClick={() => setLayer(false)}
+        primary
+      />
     </Box>
   </Layer>
 );

--- a/src/components/hackshack/Layout/index.js
+++ b/src/components/hackshack/Layout/index.js
@@ -32,7 +32,10 @@ const Layout = ({ children, background }) => {
   return (
     <ResponsiveLayout justify="between" layer={layer}>
       <Box>
-        <Grommet theme={lightTheme}>
+        <Grommet
+          theme={lightTheme}
+          style={{ position: 'sticky', top: 0, zIndex: 10 }}
+        >
           {location.pathname.includes('/hackshack') && size !== 'small' ? (
             <HPEDevHeader data={data} />
           ) : (

--- a/src/pages/hackshack/workshops/template.js
+++ b/src/pages/hackshack/workshops/template.js
@@ -1,13 +1,14 @@
 /* eslint-disable max-len */
 import React, { useEffect, useState } from 'react';
-import { Heading, Text, Box, Image, Tab, Tabs } from 'grommet';
+import { Anchor, Heading, Text, Box, Image, Tab, Tabs } from 'grommet';
+import { FormPreviousLink } from 'grommet-icons';
 import axios from 'axios';
 import PropTypes from 'prop-types';
 import { Layout, ScheduleCard, CardGrid } from '../../../components/hackshack';
 import { MainTitle } from '../../../components/hackshack/StyledComponents';
 import { SEO } from '../../../components';
 
-const APIDB = `${process.env.GATSBY_WORKSHOPCHALLENGE_API_ENDPOINT}/api`
+const APIDB = `${process.env.GATSBY_WORKSHOPCHALLENGE_API_ENDPOINT}/api`;
 
 const renderScheduleCard = (workshop, i) => (
   <ScheduleCard
@@ -50,6 +51,15 @@ const Workshop = (props) => {
   const [index, setIndex] = useState(0);
   const onActive = (nextIndex) => setIndex(nextIndex);
 
+  // Parse ?id= query param to show a single workshop when linked from home page
+  const searchParams =
+    typeof window !== 'undefined'
+      ? new URLSearchParams(window.location.search)
+      : null;
+  const linkedId = searchParams
+    ? parseInt(searchParams.get('id'), 10) || null
+    : null;
+
   const latestWorkshops = workshops
     .slice()
     .sort((a, b) => new Date(b.updatedAt) - new Date(a.updatedAt))
@@ -89,6 +99,9 @@ const Workshop = (props) => {
 
   const { title, description, badgeImg } = props.pageContext;
 
+  const linkedWorkshop = linkedId
+    ? workshops.find((w) => w.id === linkedId)
+    : null;
 
   return (
     <Layout background="/img/hackshack/BackgroundImages/schedule-background.png">
@@ -102,7 +115,23 @@ const Workshop = (props) => {
             Workshops-on-Demand
           </Heading>
         </MainTitle>
-        {workshops.length > 0 ? (
+
+        {/* Single-workshop view: linked from home page via ?id= */}
+        {linkedWorkshop ? (
+          <Box>
+            <Anchor
+              href="/hackshack/workshops"
+              icon={<FormPreviousLink />}
+              label="View all workshops"
+              color="brand"
+              margin={{ bottom: 'medium' }}
+              style={{ width: 'fit-content' }}
+            />
+            <CardGrid pad={{ top: 'small' }}>
+              {renderScheduleCard(linkedWorkshop, 0)}
+            </CardGrid>
+          </Box>
+        ) : workshops.length > 0 ? (
           <Tabs activeIndex={index} onActive={onActive} justify="start">
             <Tab title="All">
               <CardGrid pad={{ top: 'medium' }} key="all">
@@ -126,21 +155,21 @@ const Workshop = (props) => {
                 )}
               </CardGrid>
             </Tab>
-          {/* One tab per category returned by GET /workshops/categories */}
-          {categories.map((category) => (
-            <Tab
-              key={category}
-              title={category.charAt(0).toUpperCase() + category.slice(1)}
-            >
-              <CardGrid pad={{ top: 'medium' }}>
-                {workshops
-                  .filter((workshop) =>
-                    workshopMatchesCategory(workshop, category),
-                  )
-                  .map((workshop, i) => renderScheduleCard(workshop, i))}
-              </CardGrid>
-            </Tab>
-          ))}
+            {/* One tab per category returned by GET /workshops/categories */}
+            {categories.map((category) => (
+              <Tab
+                key={category}
+                title={category.charAt(0).toUpperCase() + category.slice(1)}
+              >
+                <CardGrid pad={{ top: 'medium' }}>
+                  {workshops
+                    .filter((workshop) =>
+                      workshopMatchesCategory(workshop, category),
+                    )
+                    .map((workshop, i) => renderScheduleCard(workshop, i))}
+                </CardGrid>
+              </Tab>
+            ))}
           </Tabs>
         ) : (
           <Box


### PR DESCRIPTION
- Fix Register button on home page to link to /hackshack/workshops?id=<id> instead of the replay link
- Add ?id= query param support to workshops page to show a single workshop with a back link to the full listing
- Replace gremlin background in registration panel with clean white panel
- Convert registration panel to a right-side slide-in (no backdrop) so the workshops list remains visible behind it
- Fix panel scroll gap: use dynamic headerOffset hook that measures the actual header bottom (including event banners) on mount and on scroll, so the panel always starts just below the visible header and expands to full height once the header scrolls away

## Description

<!-- What does this PR do? -->

## Changes

<!-- List the key changes -->

---

## ⚠️ Pre-merge checklist

- [ ] **Target branch is correct** — this PR targets `netlify-upgrade-dev-stories` (or another feature branch), **NOT `master`**
- [ ] Changes have been tested locally (`gatsby develop`)
- [ ] No unrelated files are included

> 🛑 **Do not merge directly to `master`**. All changes must go through a feature branch first.
