### PR TITLE
Update networking topic and open source content

### DIFF
--- a/content/opensource/SmartSim.md
+++ b/content/opensource/SmartSim.md
@@ -5,6 +5,7 @@
           github: 'https://github.com/CrayLabs/SmartSim'
           description: Enabling Machine Learning and AI for traditional high performance.
           priority: 20
+          Featured: true
           image: /img/platforms/smartsim.svg
           active: true
 ---

--- a/content/opensource/hpe_opensource.md
+++ b/content/opensource/hpe_opensource.md
@@ -1,6 +1,6 @@
 ---
           title: "HPE Open source"
-          category: Opensource
+          category: Open source
           link: https://developer.hpe.com/opensource
           description: Open-source resources from HPE.
           priority: 1

--- a/content/opensource/hpe_opensource.md
+++ b/content/opensource/hpe_opensource.md
@@ -1,6 +1,6 @@
 ---
           title: "HPE Open source"
-          category: OPENSOURCE
+          category: Opensource
           link: https://developer.hpe.com/opensource
           description: Open-source resources from HPE.
           priority: 1

--- a/content/opensource/hpe_opensource.md
+++ b/content/opensource/hpe_opensource.md
@@ -1,0 +1,11 @@
+---
+          title: "HPE Open source"
+          category: OPENSOURCE
+          link: https://developer.hpe.com/opensource
+          description: Open-source resources from HPE.
+          priority: 1
+          image: '/img/platforms/SPIFFEandSpire.svg'
+          active: true
+          Featured: true
+          github: 'https://github.com/hpe'
+---

--- a/content/opensource/hpe_opensource.md
+++ b/content/opensource/hpe_opensource.md
@@ -5,7 +5,7 @@
           description: Open-source resources from HPE.
           priority: 1
           image: '/img/platforms/SPIFFEandSpire.svg'
-          active: true
+          active: false
           Featured: true
           github: 'https://github.com/hpe'
 ---

--- a/content/opensource/spiffe-and-spire-projects.md
+++ b/content/opensource/spiffe-and-spire-projects.md
@@ -7,6 +7,6 @@
           image: '/img/platforms/SPIFFEandSpire.svg'
           active: true
           Featured: true
-          github: 'https://github.com/spiffe/spire'
+          github: 'https://github.com/spiffe'
 ---
           

--- a/content/topic/networking.md
+++ b/content/topic/networking.md
@@ -18,5 +18,5 @@ tags:
 priority: 3
 active: true
 ctaLabel: Get started with Networking
-ctaLink: <https://developer.networking.hpe.com/get-started/home/>
-learnMoreLink: <https://developer.networking.hpe.com/--->
+ctaLink: https://developer.networking.hpe.com/get-started/home
+learnMoreLink: https://developer.networking.hpe.com---

--- a/content/topic/networking.md
+++ b/content/topic/networking.md
@@ -19,4 +19,5 @@ priority: 3
 active: true
 ctaLabel: Get started with Networking
 ctaLink: https://developer.networking.hpe.com/get-started/home
-learnMoreLink: https://developer.networking.hpe.com---
+learnMoreLink: https://developer.networking.hpe.com
+---


### PR DESCRIPTION
## Summary
- update the networking topic CTA and learn more links
- add the HPE Open Source entry
- mark SmartSim as featured
- update the SPIFFE and SPIRE GitHub link

## Notes
- based on branch `fix-topic-networking-opensource`
- targets `testing`